### PR TITLE
Removed references from math utility functions

### DIFF
--- a/programs/pathfinder/src/instructions/borrow.rs
+++ b/programs/pathfinder/src/instructions/borrow.rs
@@ -119,9 +119,9 @@ impl<'info> Borrow<'info> {
         accrue_interest(market)?;
         
         if assets > 0 {
-            shares = to_shares_up(&assets, &market.total_borrow_assets, &market.total_borrow_shares)?;
+            shares = to_shares_up(assets, market.total_borrow_assets, market.total_borrow_shares)?;
         } else {
-            assets = to_assets_down(&shares, &market.total_borrow_assets, &market.total_borrow_shares)?;
+            assets = to_assets_down(shares, market.total_borrow_assets, market.total_borrow_shares)?;
         }
 
         // check if user is solvent after borrowing
@@ -186,9 +186,9 @@ pub fn is_solvent(
 
     // Calculate borrowed amount by converting borrow shares to assets, rounding up
     let mut borrowed = to_assets_up(
-        &borrow_shares,
-        &market.total_borrow_assets,
-        &market.total_borrow_shares,
+        borrow_shares,
+        market.total_borrow_assets,
+        market.total_borrow_shares,
     )?;
 
     // if fee is active, add fee to borrowed amount

--- a/programs/pathfinder/src/instructions/deposit.rs
+++ b/programs/pathfinder/src/instructions/deposit.rs
@@ -90,9 +90,9 @@ impl<'info> Deposit<'info> {
         accrue_interest(market)?;
         
         if assets > 0 {
-            shares = to_shares_down(&assets, &market.total_quote, &market.total_shares)?;
+            shares = to_shares_down(assets, market.total_quote, market.total_shares)?;
         } else {
-            assets = to_assets_up(&shares, &market.total_quote, &market.total_shares)?;
+            assets = to_assets_up(shares, market.total_quote, market.total_shares)?;
         }
         
         msg!("Depositing {} to vault", assets);

--- a/programs/pathfinder/src/instructions/liquidate.rs
+++ b/programs/pathfinder/src/instructions/liquidate.rs
@@ -156,17 +156,17 @@ impl<'info> Liquidate<'info> {
           let collateral_quoted = mul_div_up(collateral_amount as u128, collateral_price as u128, price_scale as u128)?;
 
           repay_shares = to_shares_up(
-              &w_div_up(collateral_quoted, liquidation_incentive_factor)?,
-              &market.total_borrow_assets,
-              &market.total_borrow_shares
+              w_div_up(collateral_quoted, liquidation_incentive_factor)?,
+              market.total_borrow_assets,
+              market.total_borrow_shares
           )?;
 
         } else {
 
           let shares_to_collateral = to_assets_down(
-              &repay_shares,
-              &market.total_borrow_assets,
-              &market.total_borrow_shares
+              repay_shares,
+              market.total_borrow_assets,
+              market.total_borrow_shares
           )?;
 
           let collateral_with_incentive = w_mul_down(shares_to_collateral, liquidation_incentive_factor)?;
@@ -175,9 +175,9 @@ impl<'info> Liquidate<'info> {
         }
 
         let repaid_quote = to_assets_up(
-            &repay_shares,
-            &market.total_borrow_assets,
-            &market.total_borrow_shares
+            repay_shares,
+            market.total_borrow_assets,
+            market.total_borrow_shares
         )?;
 
         borrower_shares.borrow_shares = borrower_shares.borrow_shares.checked_sub(repay_shares).unwrap();
@@ -203,9 +203,9 @@ impl<'info> Liquidate<'info> {
           bad_debt = min_u64(
               market.total_borrow_assets,
               to_assets_up(
-                &bad_debt_shares,
-                &market.total_borrow_assets,
-                &market.total_borrow_shares
+                bad_debt_shares,
+                market.total_borrow_assets,
+                market.total_borrow_shares
               )?
           );
 

--- a/programs/pathfinder/src/instructions/repay.rs
+++ b/programs/pathfinder/src/instructions/repay.rs
@@ -112,9 +112,9 @@ impl<'info> Repay<'info> {
             fee = restriction_fee(assets, collateral.last_active_timestamp)?;
             assets = assets.checked_sub(fee).ok_or(MarketError::MathOverflow)?;
 
-            shares = to_shares_down(&assets, &market.total_quote, &market.total_shares)?;
+            shares = to_shares_down(assets, market.total_quote, market.total_shares)?;
         } else {
-            assets = to_assets_up(&shares, &market.total_quote, &market.total_shares)?;
+            assets = to_assets_up(shares, market.total_quote, market.total_shares)?;
 
             fee = restriction_fee(assets, collateral.last_active_timestamp)?;
         }

--- a/programs/pathfinder/src/instructions/withdraw.rs
+++ b/programs/pathfinder/src/instructions/withdraw.rs
@@ -86,9 +86,9 @@ impl<'info> Withdraw<'info> {
         accrue_interest(market)?;
 
         if assets > 0 {
-            shares = to_shares_up(&assets, &market.total_quote, &market.total_shares)?;
+            shares = to_shares_up(assets, market.total_quote, market.total_shares)?;
         } else {
-            assets = to_assets_down(&shares, &market.total_quote, &market.total_shares)?;
+            assets = to_assets_down(shares, market.total_quote, market.total_shares)?;
         }
 
         // Validate that the user isn't requesting more shares than they possess

--- a/programs/pathfinder/src/math/shares.rs
+++ b/programs/pathfinder/src/math/shares.rs
@@ -7,50 +7,50 @@ use crate::math::*;
 const VIRTUAL_SHARES: u128 = 1_000_000; // 1e6
 const VIRTUAL_ASSETS: u128 = 1;
 
-pub fn calculate_total_assets(total_assets: &u64) -> Result<u128> {
-    (*total_assets as u128)
+pub fn calculate_total_assets(total_assets: u64) -> Result<u128> {
+    (total_assets as u128)
         .checked_add(VIRTUAL_ASSETS)
         .ok_or(error!(MarketError::MathOverflow))
 }
 
-pub fn calculate_total_shares(total_shares: &u64) -> Result<u128> {
-    (*total_shares as u128)
+pub fn calculate_total_shares(total_shares: u64) -> Result<u128> {
+    (total_shares as u128)
         .checked_add(VIRTUAL_SHARES)
         .ok_or(error!(MarketError::MathOverflow))
 }
 
 // Calculates the value of `assets` quoted in shares, rounding down.
-pub fn to_shares_down(assets: &u64, total_assets: &u64, total_shares: &u64) -> Result<u64> {
+pub fn to_shares_down(assets: u64, total_assets: u64, total_shares: u64) -> Result<u64> {
     let total_assets = calculate_total_assets(total_assets)?;
     let total_shares = calculate_total_shares(total_shares)?;
-    let assets_u128 = *assets as u128;
+    let assets_u128 = assets as u128;
 
     mul_div_down(assets_u128, total_shares, total_assets)
 }
 
 // Calculates the value of `shares` quoted in assets, rounding down.
-pub fn to_assets_down(shares: &u64, total_assets: &u64, total_shares: &u64) -> Result<u64> {
+pub fn to_assets_down(shares: u64, total_assets: u64, total_shares: u64) -> Result<u64> {
     let total_assets = calculate_total_assets(total_assets)?;
     let total_shares = calculate_total_shares(total_shares)?;
-    let shares_u128 = *shares as u128;
+    let shares_u128 = shares as u128;
 
     mul_div_down(shares_u128, total_assets, total_shares)
 }
 
 // Calculates the value of `assets` quoted in shares, rounding up.
-pub fn to_shares_up(assets: &u64, total_assets: &u64, total_shares: &u64) -> Result<u64> {
+pub fn to_shares_up(assets: u64, total_assets: u64, total_shares: u64) -> Result<u64> {
     let total_assets = calculate_total_assets(total_assets)?;
     let total_shares = calculate_total_shares(total_shares)?;
-    let assets_u128 = *assets as u128;
+    let assets_u128 = assets as u128;
 
     mul_div_up(assets_u128, total_shares, total_assets)
 }
 
 // Calculates the value of `shares` quoted in assets, rounding up.
-pub fn to_assets_up(shares: &u64, total_assets: &u64, total_shares: &u64) -> Result<u64> {
+pub fn to_assets_up(shares: u64, total_assets: u64, total_shares: u64) -> Result<u64> {
     let total_assets = calculate_total_assets(total_assets)?;
     let total_shares = calculate_total_shares(total_shares)?;
-    let shares_u128 = *shares as u128;
+    let shares_u128 = shares as u128;
 
     mul_div_up(shares_u128, total_assets, total_shares)
 }

--- a/programs/pathfinder/src/math/tests.rs
+++ b/programs/pathfinder/src/math/tests.rs
@@ -6,16 +6,16 @@ mod tests {
 
     #[test]
     fn test_calculate_total_assets() {
-        assert_eq!(calculate_total_assets(&0).unwrap(), 1);
-        assert_eq!(calculate_total_assets(&100).unwrap(), 101);
-        assert_eq!(calculate_total_assets(&u64::MAX).unwrap(), u64::MAX as u128 + 1);
+        assert_eq!(calculate_total_assets(0).unwrap(), 1);
+        assert_eq!(calculate_total_assets(100).unwrap(), 101);
+        assert_eq!(calculate_total_assets(u64::MAX).unwrap(), u64::MAX as u128 + 1);
     }
     #[test]
     fn test_calculate_total_shares() {
-        assert_eq!(calculate_total_shares(&0).unwrap(), 1_000_000);
-        assert_eq!(calculate_total_shares(&100).unwrap(), 1_000_100);
+        assert_eq!(calculate_total_shares(0).unwrap(), 1_000_000);
+        assert_eq!(calculate_total_shares(100).unwrap(), 1_000_100);
 
-        let result = calculate_total_shares(&u64::MAX).unwrap();
+        let result = calculate_total_shares(u64::MAX).unwrap();
         let expected = (u64::MAX as u128) + 1_000_000;
         assert_eq!(result, expected);
     }
@@ -24,48 +24,48 @@ mod tests {
     fn test_to_shares_down() {
 
         // Test with zero assets
-        assert_eq!(to_shares_down(&0, &100, &1000).unwrap(), 0);
+        assert_eq!(to_shares_down(0, 100, 1000).unwrap(), 0);
 
         // Test with one asset
-        assert_eq!(to_shares_down(&1, &0, &0).unwrap(), 1_000_000);
+        assert_eq!(to_shares_down(1, 0, 0).unwrap(), 1_000_000);
     }
 
     #[test]
     fn test_to_assets_down() {
         // Test with zero shares
-        assert_eq!(to_assets_down(&0, &100, &1000).unwrap(), 0);
+        assert_eq!(to_assets_down(0, 100, 1000).unwrap(), 0);
 
         // Test with one share
-        assert_eq!(to_assets_down(&1, &0, &0).unwrap(), 0);
+        assert_eq!(to_assets_down(1, 0, 0).unwrap(), 0);
 
         // Test with one share, large total_assets
-        assert_eq!(to_assets_down(&1, &u64::MAX, &1000).unwrap(), 18_428_315_757_951);
+        assert_eq!(to_assets_down(1, u64::MAX, 1000).unwrap(), 18_428_315_757_951);
 
     }
 
     #[test]
     fn test_to_shares_up() {
         // Test with zero assets
-        assert_eq!(to_shares_up(&0, &100, &100_000_000).unwrap(), 0);
+        assert_eq!(to_shares_up(0, 100, 100_000_000).unwrap(), 0);
 
         // Test with zero assets
-        assert_eq!(to_shares_up(&10, &100, &100_000_000).unwrap(), 10_000_000);
+        assert_eq!(to_shares_up(10, 100, 100_000_000).unwrap(), 10_000_000);
     }
 
     #[test]
     fn test_to_assets_up() {
         // Test with zero shares
-        assert_eq!(to_assets_up(&0, &100, &100_000_000).unwrap(), 0);
+        assert_eq!(to_assets_up(0, 100, 100_000_000).unwrap(), 0);
 
         // Test with equal assets and shares
-        assert_eq!(to_assets_up(&100, &100, &100_000_000).unwrap(), 1);
+        assert_eq!(to_assets_up(100, 100, 100_000_000).unwrap(), 1);
     }
 
     #[test]
     #[should_panic(expected = "MathOverflow")]
     fn test_overflow() {
         // This should cause an overflow
-        to_shares_down(&u64::MAX, &1, &u64::MAX).unwrap();
+        to_shares_down(u64::MAX, 1, u64::MAX).unwrap();
     }
 
 
@@ -82,7 +82,7 @@ mod tests {
         let attacker_deposit = 1; // Minimum possible deposit
 
         // Step 1: Attacker front-runs with a minimal deposit
-        let attacker_shares = to_shares_down(&attacker_deposit, &total_assets, &total_shares).unwrap();
+        let attacker_shares = to_shares_down(attacker_deposit, total_assets, total_shares).unwrap();
         println!("Attacker deposit: {}, shares received: {}", attacker_deposit, attacker_shares);
 
         // Update total assets and shares
@@ -90,7 +90,7 @@ mod tests {
         total_shares += attacker_shares;
 
         // Step 2: Large deposit comes in
-        let large_deposit_shares = to_shares_down(&large_deposit, &total_assets, &total_shares).unwrap();
+        let large_deposit_shares = to_shares_down(large_deposit, total_assets, total_shares).unwrap();
         println!("Large deposit: {}, shares received: {}", large_deposit, large_deposit_shares);
 
         // Update total assets and shares
@@ -103,7 +103,7 @@ mod tests {
         println!("Attacker's ownership fraction: {} / {}", attacker_shares, total_shares);
 
         // Step 4: Attacker withdraws
-        let attacker_assets = to_assets_down(&attacker_shares, &total_assets, &total_shares).unwrap();
+        let attacker_assets = to_assets_down(attacker_shares, total_assets, total_shares).unwrap();
         assert_eq!(attacker_assets, attacker_deposit, "Attacker should receive the same assets as he deposited");
 
         // Update total assets and shares
@@ -111,7 +111,7 @@ mod tests {
         total_shares -= attacker_shares;
 
         // Step 5: Depositor withdraws
-        let large_depositor_assets = to_assets_down(&large_deposit_shares, &total_assets, &total_shares).unwrap();
+        let large_depositor_assets = to_assets_down(large_deposit_shares, total_assets, total_shares).unwrap();
         assert_eq!(large_depositor_assets, large_deposit, "Large depositor should receive the same assets as he deposited");
     }
 


### PR DESCRIPTION
In rust it's best practice to pass values for small, easy to copy values and pass references for large hard to copy values.

These math utility functions handle small easy to copy uint values. Made more sense for the values to be passed.