### PR TITLE
Deposit

### DIFF
--- a/programs/assistant-to-the-regional-manager/src/error.rs
+++ b/programs/assistant-to-the-regional-manager/src/error.rs
@@ -18,8 +18,11 @@ pub enum ManagerError {
     #[msg("Unauthorized market")]
     UnauthorizedMarket,
 
-    #[msg("Invalid market config")]
-    InvalidMarketConfig,
+    #[msg("Invalid manager market config")]
+    InvalidManagerMarketConfig,
+
+    #[msg("Invalid pathfinder market config")]
+    InvalidPathfinderMarketConfig,
 
     #[msg("Market is not enabled")]
     MarketNotEnabled,
@@ -105,4 +108,7 @@ pub enum ManagerError {
 
     #[msg("Lender shares account is not initialized")]
     LenderSharesAccountNotInitialized,
+
+    #[msg("Invalid lender shares")]
+    InvalidLenderShares,
 }

--- a/programs/assistant-to-the-regional-manager/src/error.rs
+++ b/programs/assistant-to-the-regional-manager/src/error.rs
@@ -94,8 +94,8 @@ pub enum ManagerError {
     #[msg("Market cap reached")]
     MarketCapReached,
 
-    #[msg("Invalid supply queue account")]
-    InvalidSupplyQueueAccount,
+    #[msg("Invalid supply queue")]
+    InvalidSupplyQueue,
 
     #[msg("Number of remaining accounts and supply queue don't match")]
     RemainingAccountsMismatch,

--- a/programs/assistant-to-the-regional-manager/src/error.rs
+++ b/programs/assistant-to-the-regional-manager/src/error.rs
@@ -93,4 +93,16 @@ pub enum ManagerError {
 
     #[msg("Market cap reached")]
     MarketCapReached,
+
+    #[msg("Invalid supply queue account")]
+    InvalidSupplyQueueAccount,
+
+    #[msg("Number of remaining accounts and supply queue don't match")]
+    RemainingAccountsMismatch,
+
+    #[msg("Market removal exists in supply queue")]
+    InvalidMarketRemovalExistsInSupplyQueue,
+
+    #[msg("Lender shares account is not initialized")]
+    LenderSharesAccountNotInitialized,
 }

--- a/programs/assistant-to-the-regional-manager/src/error.rs
+++ b/programs/assistant-to-the-regional-manager/src/error.rs
@@ -88,26 +88,11 @@ pub enum ManagerError {
     #[msg("Invalid pathfinder market")]
     InvalidPathfinderMarket,
 
-    #[msg("Invalid pathfinder lender shares")]
-    InvalidPathfinderLenderShares,
-
-    #[msg("Market queue mismatch")]
-    MarketQueueMismatch,
-
     #[msg("Market cap reached")]
     MarketCapReached,
 
     #[msg("Invalid supply queue")]
     InvalidSupplyQueue,
-
-    #[msg("Number of remaining accounts and supply queue don't match")]
-    RemainingAccountsMismatch,
-
-    #[msg("Market removal exists in supply queue")]
-    InvalidMarketRemovalExistsInSupplyQueue,
-
-    #[msg("Lender shares account is not initialized")]
-    LenderSharesAccountNotInitialized,
 
     #[msg("Invalid lender shares")]
     InvalidLenderShares,

--- a/programs/assistant-to-the-regional-manager/src/instructions/accept_cap.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/accept_cap.rs
@@ -45,7 +45,7 @@ pub struct AcceptCap<'info> {
         ],
         bump,
     )]
-    pub market_config: Box<Account<'info, MarketConfig>>,
+    pub market_config: Box<Account<'info, ManagerMarketConfig>>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/assistant-to-the-regional-manager/src/instructions/create_manager.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/create_manager.rs
@@ -67,11 +67,7 @@ impl<'info> CreateManager<'info> {
   pub fn handle(ctx: Context<CreateManager>, args: CreateManagerArgs) -> Result<()> {
 
     let CreateManager {
-      user,
       config,
-      system_program,
-      rent,
-      token_metadata_program,
       quote_mint,
       queue,
       ..

--- a/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
@@ -48,15 +48,16 @@ pub struct Deposit<'info> {
         bump = queue.bump,
     )]
     pub queue: Box<Account<'info, QueueState>>,
- 
+    
+    // TODO: initialize in whereever we set fee_recipient
     #[account(
         init_if_needed,
         payer = user,
         space = 8 + std::mem::size_of::<SupplyShares>(),
         seeds = [
             MANAGER_SHARES_SEED_PREFIX,
-            &config.key().as_ref(),
-            &config.fee_recipient.key().as_ref()
+            config.key().as_ref(),
+            config.fee_recipient.key().as_ref()
         ],
         bump
     )]
@@ -68,16 +69,19 @@ pub struct Deposit<'info> {
         space = 8 + std::mem::size_of::<SupplyShares>(),
         seeds = [
             MANAGER_SHARES_SEED_PREFIX,
-            &config.key().as_ref(),
-            &args.receiver.key().as_ref()
+            config.key().as_ref(),
+            args.receiver.key().as_ref()
         ],
         bump
     )]
     pub receiver_shares: Account<'info, SupplyShares>,
 
     // pathfinder accounts
+    #[account(mut)]
     pub pathfinder_config: Account<'info, Config>,
+    #[account(mut)]
     pub vault_ata_quote: Account<'info, TokenAccount>,
+    #[account(mut)]
     pub user_ata_quote: Account<'info, TokenAccount>,
 
     pub system_program: Program<'info, System>,
@@ -86,39 +90,27 @@ pub struct Deposit<'info> {
 
     // NOTE: remaining accounts are pathfinder market and lender shares accounts.
     // These are not specified here but are passed in the context
-    // the accounts are in threes [market, lender_shares, market_config, ...]
+    // the accounts are ordered by supply queue in threes [market, lender_shares, market_config, ...]
+    // Any excess accounts which exist in the withdraw queue but not in supply queue are tacked onto the end
 }
 
-impl<'info> CuratorProtection<'info> for Deposit<'info> {}
 impl<'info, 'c: 'info> VaultAccounting<'info, 'c> for Deposit<'info> {}
 impl<'info, 'c: 'info> PathActions<'info, 'c> for Deposit<'info> {}
 impl<'info, 'c: 'info> Deposit<'info> {
 
-    pub fn validate(&self, args: &DepositArgs) -> Result<()> {
-        self.is_curator(&self.user, &self.config)?;
-        Ok(())
-    }
-
     pub fn handle(ctx: Context<'_, '_, 'c, 'info, Deposit<'info>>, args: DepositArgs) -> Result<()> {
 
+        // Protects against edgecase supplyqueue.len() > withdraw_queue.len()
+        // The guardian must set a new supply queue without the removed market.
+        // drastically reduces complexity of the deposit account checking logic
+        // msg!("remaining accounts: {:?}", ctx.remaining_accounts.len() / 3);
+        // msg!("withdraw queue: {:?}", ctx.accounts.queue.withdraw_queue.len());
+
+        // if ctx.accounts.queue.withdraw_queue.len() != ctx.remaining_accounts.len() / 3 {
+        //     return err!(ManagerError::MarketQueueMismatch);
+        // }
+
         let (fee_shares, new_total_assets) = Self::_accrued_fee_shares(&ctx)?;
-
-        // let Deposit {
-        //     user,
-        //     config,
-        //     fee_recipient_shares,
-        //     receiver_shares,
-        //     queue,
-        //     pathfinder_config,
-        //     pathfinder_program,
-        //     vault_ata_quote,
-        //     user_ata_quote,
-        //     token_program,
-        //     system_program,
-        //     ..
-        // } = ctx.accounts;
-
-        let mut assets = args.assets;
 
         if fee_shares != 0 {
             ctx.accounts.fee_recipient_shares.shares = ctx.accounts.fee_recipient_shares.shares
@@ -137,21 +129,10 @@ impl<'info, 'c: 'info> Deposit<'info> {
             ctx.accounts.config.decimals_offset,
             false
         )?;
-
-        // Supply assets to Pathfinder markets
+ 
         Self::_supply_path(
             &ctx,
-            &mut assets,
-            // user,
-            // config,
-            // queue,
-            // pathfinder_config,
-            // pathfinder_program,
-            // vault_ata_quote,
-            // user_ata_quote,
-            // token_program,
-            // system_program,
-            // remaining_accounts
+            args.assets,
         )?;
 
         ctx.accounts.receiver_shares.shares = ctx.accounts.receiver_shares.shares
@@ -162,6 +143,7 @@ impl<'info, 'c: 'info> Deposit<'info> {
         ctx.accounts.config.last_total_assets = ctx.accounts.config.last_total_assets
             .checked_add(args.assets)
             .ok_or(ManagerError::MathOverflow)?;
+
 
         Ok(())
     }

--- a/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
@@ -90,7 +90,7 @@ pub struct Deposit<'info> {
 
     // NOTE: remaining accounts are pathfinder market and lender shares accounts.
     // These are not specified here but are passed in the context
-    // the accounts are ordered by supply queue in threes [market, lender_shares, market_config, ...]
+    // the accounts are ordered by supply queue in threes [market, lender_shares, manager_market_config, ...]
     // Any excess accounts which exist in the withdraw queue but not in supply queue are tacked onto the end
 }
 
@@ -113,7 +113,7 @@ impl<'info, 'c: 'info> Deposit<'info> {
         ctx.accounts.config.last_total_assets = new_total_assets;
 
         let shares = Self::_convert_to_shares_with_totals(
-            args.assets, 
+            args.assets,
             ctx.accounts.config.total_shares,
             new_total_assets,
             ctx.accounts.config.decimals_offset,
@@ -133,7 +133,6 @@ impl<'info, 'c: 'info> Deposit<'info> {
         ctx.accounts.config.last_total_assets = ctx.accounts.config.last_total_assets
             .checked_add(args.assets)
             .ok_or(ManagerError::MathOverflow)?;
-
 
         Ok(())
     }

--- a/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
@@ -100,16 +100,6 @@ impl<'info, 'c: 'info> Deposit<'info> {
 
     pub fn handle(ctx: Context<'_, '_, 'c, 'info, Deposit<'info>>, args: DepositArgs) -> Result<()> {
 
-        // Protects against edgecase supplyqueue.len() > withdraw_queue.len()
-        // The guardian must set a new supply queue without the removed market.
-        // drastically reduces complexity of the deposit account checking logic
-        // msg!("remaining accounts: {:?}", ctx.remaining_accounts.len() / 3);
-        // msg!("withdraw queue: {:?}", ctx.accounts.queue.withdraw_queue.len());
-
-        // if ctx.accounts.queue.withdraw_queue.len() != ctx.remaining_accounts.len() / 3 {
-        //     return err!(ManagerError::MarketQueueMismatch);
-        // }
-
         let (fee_shares, new_total_assets) = Self::_accrued_fee_shares(&ctx)?;
 
         if fee_shares != 0 {

--- a/programs/assistant-to-the-regional-manager/src/instructions/remove_from_withdraw_queue.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/remove_from_withdraw_queue.rs
@@ -49,7 +49,7 @@ pub struct RemoveFromWithdrawQueue<'info> {
         ],
         bump,
     )]
-    pub market_config: Box<Account<'info, MarketConfig>>,
+    pub market_config: Box<Account<'info, ManagerMarketConfig>>,
 
     // queue are the market accounts from the pathfinder program
     #[account(

--- a/programs/assistant-to-the-regional-manager/src/instructions/revoke_cap.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/revoke_cap.rs
@@ -32,7 +32,7 @@ pub struct RevokePendingCap<'info> {
         ],
         bump,
     )]
-    pub market_config: Box<Account<'info, MarketConfig>>,
+    pub market_config: Box<Account<'info, ManagerMarketConfig>>,
 }
 
 impl<'info> CuratorOrGuardianProtection<'info> for RevokePendingCap<'info> {}
@@ -56,4 +56,3 @@ impl<'info> RevokePendingCap<'info> {
         Ok(())
     }
 }
-

--- a/programs/assistant-to-the-regional-manager/src/instructions/set_supply_queue.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/set_supply_queue.rs
@@ -3,7 +3,7 @@ use anchor_spl::token::*;
 
 use crate::state::*;
 use crate::error::*;
-use crate::utils::accounts::{load_market_config, validate_market_config_pda};
+use crate::utils::accounts::{validate_manager_market_config_pda};
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct SetSupplyQueueArgs {
@@ -49,8 +49,8 @@ pub struct SetSupplyQueue<'info> {
     // These are not specified here but are passed in the context
 }
 
-impl<'info> SetSupplyQueue<'info> {
-    pub fn handle(ctx: Context<SetSupplyQueue>, args: SetSupplyQueueArgs) -> Result<()> {
+impl<'info, 'c: 'info> SetSupplyQueue<'info> {
+    pub fn handle(ctx: Context<'_, '_, 'c, 'info, SetSupplyQueue<'info>>, args: SetSupplyQueueArgs) -> Result<()> {
         let SetSupplyQueue {
           config,
           queue,
@@ -65,16 +65,19 @@ impl<'info> SetSupplyQueue<'info> {
         // Verify all markets in queue are authorized
         for (i, path_market_pubkey) in args.market_ids.iter().enumerate() {
 
-          // retreive configs for each market account
-          let market_config = load_market_config(&ctx.remaining_accounts[i])?;
+          let market_config_info = &ctx.remaining_accounts[i];
 
-          validate_market_config_pda(
-            &ctx.remaining_accounts[i],
-            &config.key(),
-            path_market_pubkey,
+          // retreive configs for each market account
+          // let manager_market_config = load_manager_market_config(market_config_info)?;
+          let manager_market_config_account = Account::<ManagerMarketConfig>::try_from(&market_config_info)?;
+
+          validate_manager_market_config_pda(
+            &market_config_info.key(),
+            &path_market_pubkey,
+            &config.key()
           )?;
- 
-          if market_config.cap == 0 {
+
+          if manager_market_config_account.cap == 0 {
             return err!(ManagerError::UnauthorizedMarket);
           }
         }

--- a/programs/assistant-to-the-regional-manager/src/instructions/submit_cap.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/submit_cap.rs
@@ -42,7 +42,7 @@ pub struct SubmitCap<'info> {
     #[account(
         init_if_needed,
         payer = user,
-        space = 8 + std::mem::size_of::<MarketConfig>(),
+        space = 8 + std::mem::size_of::<ManagerMarketConfig>(),
         seeds = [
             MANAGER_MARKET_CONFIG_SEED_PREFIX,
             config.key().as_ref(),
@@ -50,7 +50,7 @@ pub struct SubmitCap<'info> {
         ],
         bump,
     )]
-    pub market_config: Box<Account<'info, MarketConfig>>,
+    pub market_config: Box<Account<'info, ManagerMarketConfig>>,
 
     // errors if market account is not initialized
     #[account(
@@ -114,7 +114,7 @@ impl<'info> SubmitCap<'info> {
 
 pub fn set_cap(
     queue: &mut QueueState,
-    market_config: &mut MarketConfig,
+    market_config: &mut ManagerMarketConfig,
     market_id: Pubkey,
     new_cap: u64
 ) -> Result<()> {

--- a/programs/assistant-to-the-regional-manager/src/instructions/submit_market_removal.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/submit_market_removal.rs
@@ -44,7 +44,7 @@ pub struct SubmitMarketRemoval<'info> {
         ],
         bump,
     )]
-    pub market_config: Box<Account<'info, MarketConfig>>,
+    pub market_config: Box<Account<'info, ManagerMarketConfig>>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/assistant-to-the-regional-manager/src/lib.rs
+++ b/programs/assistant-to-the-regional-manager/src/lib.rs
@@ -37,7 +37,10 @@ pub mod assistant_to_the_regional_manager {
         SubmitMarketRemoval::handle(ctx, args)
     }
 
-    pub fn set_supply_queue(ctx: Context<SetSupplyQueue>, args: SetSupplyQueueArgs) -> Result<()> {
+    pub fn set_supply_queue<'c: 'info, 'info>(
+        ctx: Context<'_, '_, 'c, 'info, SetSupplyQueue<'info>>,
+        args: SetSupplyQueueArgs
+    ) -> Result<()> {
         SetSupplyQueue::handle(ctx, args)
     }
 

--- a/programs/assistant-to-the-regional-manager/src/lib.rs
+++ b/programs/assistant-to-the-regional-manager/src/lib.rs
@@ -89,7 +89,6 @@ pub mod assistant_to_the_regional_manager {
         RevokePendingTimelock::handle(ctx)
     }
 
-    #[access_control(ctx.accounts.validate(&args))]
     pub fn deposit<'c: 'info, 'info>(
         ctx: Context<'_, '_, 'c, 'info, Deposit<'info>>,
         args: DepositArgs

--- a/programs/assistant-to-the-regional-manager/src/state/mod.rs
+++ b/programs/assistant-to-the-regional-manager/src/state/mod.rs
@@ -68,8 +68,8 @@ pub struct MarketConfig {
 #[account]
 pub struct QueueState {
   pub bump: u8,
-  pub supply_queue: Vec<Pubkey>,    // Vector of market IDs
-  pub withdraw_queue: Vec<Pubkey>,   // Vector of market IDs
+  pub supply_queue: Vec<Pubkey>,                // Vector of market IDs
+  pub withdraw_queue: Vec<Pubkey>,              // Vector of market IDs
 }
 
 // Pending State Account - Stores pending changes

--- a/programs/assistant-to-the-regional-manager/src/state/mod.rs
+++ b/programs/assistant-to-the-regional-manager/src/state/mod.rs
@@ -9,6 +9,7 @@ pub use pending_type::*;
 // Config Account - Contains core configuration and authority data
 // Config Account - Main vault configuration
 // This is the main config account for each vault instance
+// owner of postitions in pathfinder markets
 #[account]
 pub struct ManagerVaultConfig {
   pub bump: u8,
@@ -52,12 +53,12 @@ pub struct SupplyShares {
 // ["managermarketconfig", vault_address, market_id]
 // in queue methods MarketConfigs are passed as remaining accounts
 #[account]
-pub struct MarketConfig {
+pub struct ManagerMarketConfig {
   pub bump: u8,
   pub enabled: bool,
   pub cap: u64,                  // Supply cap for this market
   pub removable_at: u64,         // Timestamp when market can be removed
-  pub pending_cap: PendingU64,   // Pending cap change
+  pub pending_cap: PendingU64,          // Pending cap for this market
 }
 
 // Queue Account - Stores supply and withdraw queues

--- a/programs/assistant-to-the-regional-manager/src/state/mod.rs
+++ b/programs/assistant-to-the-regional-manager/src/state/mod.rs
@@ -58,7 +58,7 @@ pub struct ManagerMarketConfig {
   pub enabled: bool,
   pub cap: u64,                  // Supply cap for this market
   pub removable_at: u64,         // Timestamp when market can be removed
-  pub pending_cap: PendingU64,          // Pending cap for this market
+  pub pending_cap: PendingU64,   // Pending cap for this market
 }
 
 // Queue Account - Stores supply and withdraw queues
@@ -69,8 +69,8 @@ pub struct ManagerMarketConfig {
 #[account]
 pub struct QueueState {
   pub bump: u8,
-  pub supply_queue: Vec<Pubkey>,                // Vector of market IDs
-  pub withdraw_queue: Vec<Pubkey>,              // Vector of market IDs
+  pub supply_queue: Vec<Pubkey>,    // Vector of market IDs
+  pub withdraw_queue: Vec<Pubkey>,  // Vector of market IDs
 }
 
 // Pending State Account - Stores pending changes

--- a/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
+++ b/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
@@ -4,13 +4,13 @@ use crate::{
   state::*, 
   error::ManagerError,
   instructions::Deposit,
+  utils::accounts::validate_manager_market_config_pda
 };
 
 use pathfinder::{
-    program::Pathfinder,
     cpi::{accrue_interest, deposit},
-    math::{min_u64, mul_div_down, mul_div_up, to_assets_up, zero_floor_sub, WAD},
-    state::{Config, LenderShares, Market},
+    math::{min_u64, to_assets_up, zero_floor_sub},
+    state::{LenderShares, Market},
 };
 pub trait PathActions<'info, 'c: 'info> {
 
@@ -34,35 +34,43 @@ pub trait PathActions<'info, 'c: 'info> {
 
     for i in (0..remaining_accounts.len()).step_by(3) {
 
-      let market_acc_info = &remaining_accounts[i];
-      let lender_shares_acc_info = &remaining_accounts[i + 1];
-      let market_config_acc_info = &remaining_accounts[i + 2];
+      let market_info = &remaining_accounts[i];
+      let lender_shares_info = &remaining_accounts[i + 1];
+      let manager_market_config_info = &remaining_accounts[i + 2];
 
       let mut shares: u64 = 0;
 
-      // if queue_index is greater than queue.supply_queue.len(), break
+      // if queue_index is greater than queue.supply_queue.len()
+      // we've processed all markets in the supply queue
       if queue_index >= queue.supply_queue.len() {
         break;
       }
 
       // remaining accounts must be in the same order as the supply queue
-      let market_pubkey = queue.supply_queue[queue_index];
-      let market_account = Account::<Market>::try_from(&market_acc_info)?;
-      if market_account.key() != market_pubkey {
+      let supply_queue_market = queue.supply_queue[queue_index];
+      // market_info seed derivation has already been validated in total_assets()
+      let market_account: Account<'_, Market> = Account::<Market>::try_from(&market_info)?;
+      if market_info.key() != supply_queue_market {
         return err!(ManagerError::InvalidSupplyQueue);
       }
  
-      // if initialized, validate that lender shares account data
-      if !lender_shares_acc_info.data_is_empty() {
-        let lender_account = Account::<LenderShares>::try_from(&lender_shares_acc_info)?;
+      // validate that lender shares account data
+      // lender_shares seed derivation has already been validated in total_assets()
+      if !lender_shares_info.data_is_empty() {
+        let lender_account = Account::<LenderShares>::try_from(&lender_shares_info)?;
         shares = lender_account.shares;
       }
 
-      // validate that market config account data
-      let market_config_account = Account::<MarketConfig>::try_from(&market_config_acc_info)?;
+      // validate manager market config account
+      let manager_market_config_account = Account::<ManagerMarketConfig>::try_from(&manager_market_config_info)?;
+      validate_manager_market_config_pda(
+        &manager_market_config_info.key(),
+        &market_info.key(),
+        &config.key(),
+      )?;
 
       // check supply cap, if 0, skip
-      let supply_cap = market_config_account.cap;
+      let supply_cap = manager_market_config_account.cap;
       if supply_cap == 0 {
         continue;
       }
@@ -98,9 +106,9 @@ pub trait PathActions<'info, 'c: 'info> {
           pathfinder_program.to_account_info(),
           pathfinder::cpi::accounts::Deposit {
             user: user.to_account_info(),
-            market: market_account.to_account_info(),
+            market: market_info.to_account_info(),
             config: pathfinder_config.to_account_info(),
-            lender_shares: lender_shares_acc_info.to_account_info(),
+            lender_shares: lender_shares_info.to_account_info(),
             vault_ata_quote: vault_ata_quote.to_account_info(),
             user_ata_quote: user_ata_quote.to_account_info(),
             token_program: token_program.to_account_info(),

--- a/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
+++ b/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
@@ -49,7 +49,7 @@ pub trait PathActions<'info, 'c: 'info> {
       let market_pubkey = queue.supply_queue[queue_index];
       let market_account = Account::<Market>::try_from(&market_acc_info)?;
       if market_account.key() != market_pubkey {
-        return Err(ManagerError::InvalidSupplyQueueAccount.into());
+        return err!(ManagerError::InvalidSupplyQueue);
       }
  
       // if initialized, validate that lender shares account data
@@ -127,8 +127,13 @@ pub trait PathActions<'info, 'c: 'info> {
       queue_index += 1;
     }
 
+    require!(
+      assets == 0,
+      ManagerError::MarketCapReached
+    );
+
     if assets != 0 {
-      return Err(ManagerError::MarketCapReached.into());
+      return err!(ManagerError::MarketCapReached);
     }
 
     Ok(())

--- a/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
+++ b/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::{mint_to, Mint, MintTo, Token, TokenAccount};
 use crate::{
   state::*, 
   error::ManagerError,
@@ -90,7 +89,7 @@ pub trait PathActions<'info, 'c: 'info> {
       // get supply shares for manager's position in market
       let deposit_shares = shares;
 
-      // // convert supply shares to assets, rounding up
+      // convert supply shares to assets, rounding up
       let supply_assets = to_assets_up(
         deposit_shares,
         market_account.total_deposits()?,

--- a/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
+++ b/programs/assistant-to-the-regional-manager/src/traits/path_actions.rs
@@ -16,7 +16,7 @@ pub trait PathActions<'info, 'c: 'info> {
 
   fn _supply_path(
     ctx: &Context<'_, '_, 'c, 'info, Deposit<'info>>,
-    assets: &mut u64,
+    assets: u64,
   ) -> Result<()> {
     let user = &ctx.accounts.user;
     let config = &ctx.accounts.config;
@@ -29,13 +29,38 @@ pub trait PathActions<'info, 'c: 'info> {
     let token_program = &ctx.accounts.token_program;
     let system_program = &ctx.accounts.system_program;
 
+    let mut queue_index = 0;
+    let mut assets = assets;
 
-    for i in 0..queue.supply_queue.len() {
-      let market_account = Account::<Market>::try_from(&remaining_accounts[i])?;
-      let lender_shares_account = Account::<LenderShares>::try_from(&remaining_accounts[i + 1])?;
-      let market_config_account = Account::<MarketConfig>::try_from(&remaining_accounts[i + 2])?;
+    for i in (0..remaining_accounts.len()).step_by(3) {
 
-      // get market id from queue
+      let market_acc_info = &remaining_accounts[i];
+      let lender_shares_acc_info = &remaining_accounts[i + 1];
+      let market_config_acc_info = &remaining_accounts[i + 2];
+
+      let mut shares: u64 = 0;
+
+      // if queue_index is greater than queue.supply_queue.len(), break
+      if queue_index >= queue.supply_queue.len() {
+        break;
+      }
+
+      // remaining accounts must be in the same order as the supply queue
+      let market_pubkey = queue.supply_queue[queue_index];
+      let market_account = Account::<Market>::try_from(&market_acc_info)?;
+      if market_account.key() != market_pubkey {
+        return Err(ManagerError::InvalidSupplyQueueAccount.into());
+      }
+ 
+      // if initialized, validate that lender shares account data
+      if !lender_shares_acc_info.data_is_empty() {
+        let lender_account = Account::<LenderShares>::try_from(&lender_shares_acc_info)?;
+        shares = lender_account.shares;
+      }
+
+      // validate that market config account data
+      let market_config_account = Account::<MarketConfig>::try_from(&market_config_acc_info)?;
+
       // check supply cap, if 0, skip
       let supply_cap = market_config_account.cap;
       if supply_cap == 0 {
@@ -55,9 +80,9 @@ pub trait PathActions<'info, 'c: 'info> {
       accrue_interest(accrue_ctx)?;
 
       // get supply shares for manager's position in market
-      let deposit_shares = lender_shares_account.shares;
+      let deposit_shares = shares;
 
-      // convert supply shares to assets, rounding up
+      // // convert supply shares to assets, rounding up
       let supply_assets = to_assets_up(
         deposit_shares,
         market_account.total_deposits()?,
@@ -65,8 +90,7 @@ pub trait PathActions<'info, 'c: 'info> {
       )?;
 
       // calculate toSupply as min of (supplyCap - supplyAssets, assets)
-      let to_supply = min_u64(zero_floor_sub(supply_cap, supply_assets), *assets);
-
+      let to_supply = min_u64(zero_floor_sub(supply_cap, supply_assets), assets);
 
       if to_supply > 0 {
 
@@ -76,7 +100,7 @@ pub trait PathActions<'info, 'c: 'info> {
             user: user.to_account_info(),
             market: market_account.to_account_info(),
             config: pathfinder_config.to_account_info(),
-            lender_shares: lender_shares_account.to_account_info(),
+            lender_shares: lender_shares_acc_info.to_account_info(),
             vault_ata_quote: vault_ata_quote.to_account_info(),
             user_ata_quote: user_ata_quote.to_account_info(),
             token_program: token_program.to_account_info(),
@@ -92,16 +116,18 @@ pub trait PathActions<'info, 'c: 'info> {
 
         // Skip markets that fail by catching any errors
         if deposit(deposit_ctx, deposit_args).is_ok() {
-            *assets = assets.checked_sub(to_supply).ok_or(ManagerError::MathUnderflow)?;
+            assets = assets.checked_sub(to_supply).ok_or(ManagerError::MathUnderflow)?;
         }
       }
 
-      if *assets == 0 {
+      if assets == 0 {
         break;
       }
+
+      queue_index += 1;
     }
 
-    if *assets != 0 {
+    if assets != 0 {
       return Err(ManagerError::MarketCapReached.into());
     }
 

--- a/programs/assistant-to-the-regional-manager/src/traits/vault_accounting.rs
+++ b/programs/assistant-to-the-regional-manager/src/traits/vault_accounting.rs
@@ -8,28 +8,44 @@ use crate::{
 use pathfinder::math::{mul_div_down, mul_div_up, zero_floor_sub, WAD}; 
 use pathfinder::cpi::view_expected_supply_assets;
 use pathfinder::state::{Market, LenderShares};
+use std::collections::HashSet;
+
 pub trait VaultAccounting<'info, 'c: 'info> {
 
   fn total_assets(
     ctx: &Context<'_, '_, 'c, 'info, Deposit<'info>>,
   ) -> Result<u64> {
-    let assets = 0;
-    let pathfinder_accounts = ctx.remaining_accounts;
+    let mut assets: u64 = 0;
+    let market_accounts = ctx.remaining_accounts;
     let withdraw_queue = &ctx.accounts.queue.withdraw_queue;
 
-    require!(
-        withdraw_queue.len() == pathfinder_accounts.len().checked_mul(2).unwrap(),
-        ManagerError::MarketQueueMismatch
-    );
+    // checking against set errors on duplicate and ensures all withdraw_queue accounts are accounted for
+    let withdraw_queue_set: HashSet<_> = withdraw_queue
+      .iter()
+      .map(|market| market.key())
+      .collect();
 
-    for i in 0..withdraw_queue.len() {
+    // order of withdraw queue accounts is not guaranteed
+    for i in (0..market_accounts.len()).step_by(3) {
 
-      // let market_account = &pathfinder_accounts[i];
-      let market_account = Account::<Market>::try_from(&pathfinder_accounts[i])?;
-      let lender_shares_account = Account::<LenderShares>::try_from(&pathfinder_accounts[i + 1])?;
+      // check to ensure market is in withdraw queue
+      if !withdraw_queue_set.contains(&market_accounts[i].key()) {
+        return err!(ManagerError::MarketNotInQueue);
+      }
 
-      // TODO: is validating the seed necessary? what value doe we get from it?
-      // validate_pathfinder_market(&market_account, &withdraw_queue[i])?;
+      let market_account = Account::<Market>::try_from(&market_accounts[i])?;
+
+      // validate that lender shares account is valid
+      // TODO: if try_from fails, we need a way to verify that its because this is the first deposit and not becuase the account is invalid
+      let lender_shares_account = if market_accounts[i + 1].data_is_empty() {
+          // return err!(ManagerError::LenderSharesAccountNotInitialized);
+          continue;
+      } else {
+          Account::<LenderShares>::try_from(&market_accounts[i + 1])?
+      };
+
+      // validate that seed derivation is correct
+      // validate_pathfinder_market(&market_accounts[i])?;
       // validate_pathfinder_lender_shares(&market_account.key(), &lender_shares_account.key(), &manager_config.key())?;
 
       let view_market_ctx = CpiContext::new(
@@ -42,11 +58,11 @@ pub trait VaultAccounting<'info, 'c: 'info> {
 
       let expected_assets = view_expected_supply_assets(
         view_market_ctx,
-        lender_shares_account.shares);
+        lender_shares_account.shares)?;
 
-      // msg!("expected_assets: {}", expected_assets);
-
-      // assets = assets.checked_add(expected_assets).unwrap();
+      assets = assets
+        .checked_add(expected_assets.get())
+        .ok_or(ManagerError::MathOverflow)?;
     }
 
     Ok(assets)

--- a/programs/assistant-to-the-regional-manager/src/traits/vault_accounting.rs
+++ b/programs/assistant-to-the-regional-manager/src/traits/vault_accounting.rs
@@ -29,6 +29,9 @@ pub trait VaultAccounting<'info, 'c: 'info> {
     for i in (0..market_accounts.len()).step_by(3) {
 
       // check to ensure market is in withdraw queue
+      // Also protects against edgecase supplyqueue.len() > withdraw_queue.len()
+      // The guardian must set a new supply queue without the removed market prior to depositors calling deposit.
+      // drastically reduces complexity of the deposit account checking logic
       if !withdraw_queue_set.contains(&market_accounts[i].key()) {
         return err!(ManagerError::MarketNotInQueue);
       }

--- a/programs/assistant-to-the-regional-manager/src/traits/vault_accounting.rs
+++ b/programs/assistant-to-the-regional-manager/src/traits/vault_accounting.rs
@@ -9,7 +9,10 @@ use pathfinder::math::{mul_div_down, mul_div_up, zero_floor_sub, WAD};
 use pathfinder::cpi::view_expected_supply_assets;
 use pathfinder::state::{Market, LenderShares};
 use std::collections::HashSet;
-
+use crate::utils::accounts::{
+  validate_pathfinder_market_pda, 
+  validate_pathfinder_lender_shares_pda,
+};
 pub trait VaultAccounting<'info, 'c: 'info> {
 
   fn total_assets(
@@ -18,6 +21,8 @@ pub trait VaultAccounting<'info, 'c: 'info> {
     let mut assets: u64 = 0;
     let market_accounts = ctx.remaining_accounts;
     let withdraw_queue = &ctx.accounts.queue.withdraw_queue;
+    let pathfinder_config = &ctx.accounts.pathfinder_config;
+    let manager_config_info = &ctx.accounts.config.to_account_info();
 
     // checking against set errors on duplicate and ensures all withdraw_queue accounts are accounted for
     let withdraw_queue_set: HashSet<_> = withdraw_queue
@@ -28,34 +33,36 @@ pub trait VaultAccounting<'info, 'c: 'info> {
     // order of withdraw queue accounts is not guaranteed
     for i in (0..market_accounts.len()).step_by(3) {
 
+      let market_info = &market_accounts[i];
+      let lender_shares_info = &market_accounts[i + 1];
+
       // check to ensure market is in withdraw queue
       // Also protects against edgecase supplyqueue.len() > withdraw_queue.len()
       // The guardian must set a new supply queue without the removed market prior to depositors calling deposit.
       // drastically reduces complexity of the deposit account checking logic
-      if !withdraw_queue_set.contains(&market_accounts[i].key()) {
+      if !withdraw_queue_set.contains(&market_info.key()) {
         return err!(ManagerError::MarketNotInQueue);
       }
 
-      let market_account = Account::<Market>::try_from(&market_accounts[i])?;
+      // validate market account
+      let market_account = Account::<Market>::try_from(&market_info)?;
+      validate_pathfinder_market_pda(&market_info.key(), &market_account)?;
 
-      // validate that lender shares account is valid
-      // TODO: if try_from fails, we need a way to verify that its because this is the first deposit and not becuase the account is invalid
-      let lender_shares_account = if market_accounts[i + 1].data_is_empty() {
-          // return err!(ManagerError::LenderSharesAccountNotInitialized);
-          continue;
+      // validate lender shares account
+      validate_pathfinder_lender_shares_pda(&market_info.key(), &manager_config_info.key(), &lender_shares_info.key())?;
+      let lender_shares_account = if lender_shares_info.data_is_empty() {
+        // if the lender shares account is empty market doesn't have position
+        // skip the expected assets calculation
+        continue;
       } else {
-          Account::<LenderShares>::try_from(&market_accounts[i + 1])?
+        Account::<LenderShares>::try_from(&lender_shares_info)?
       };
-
-      // validate that seed derivation is correct
-      // validate_pathfinder_market(&market_accounts[i])?;
-      // validate_pathfinder_lender_shares(&market_account.key(), &lender_shares_account.key(), &manager_config.key())?;
 
       let view_market_ctx = CpiContext::new(
         ctx.accounts.pathfinder_program.to_account_info(),
         pathfinder::cpi::accounts::ViewMarket {
-          market: market_account.to_account_info(),
-          config: ctx.accounts.pathfinder_config.to_account_info(),
+          market: market_info.to_account_info(),
+          config: pathfinder_config.to_account_info(),
         },
       );
 

--- a/programs/assistant-to-the-regional-manager/src/utils/accounts.rs
+++ b/programs/assistant-to-the-regional-manager/src/utils/accounts.rs
@@ -49,3 +49,28 @@ pub fn validate_market_config_pda(
 
     Ok(())
 }
+
+
+// Validates that a MarketConfig PDA matches expected values
+// pub fn validate_pathfinder_market_pda(
+//     ai: &AccountInfo,
+//     market: &Market,
+// ) -> Result<()> {
+
+//     let seeds = &[
+//       pathfinder::state::MARKET_SEED_PREFIX,
+//       &market.quote_mint.key().as_ref(),
+//       &market.collateral_mint.key().as_ref(),
+//       &market.ltv_factor.to_le_bytes().as_ref(),
+//       &market.oracle.id.to_bytes().as_ref(),
+//     ];
+
+//     let (expected_pda, _) = Pubkey::find_program_address(seeds, &crate::ID);
+
+//     require!(
+//         ai.key() == expected_pda,
+//         ManagerError::InvalidMarketConfig
+//     );  
+
+//     Ok(())
+// }

--- a/programs/assistant-to-the-regional-manager/src/utils/accounts.rs
+++ b/programs/assistant-to-the-regional-manager/src/utils/accounts.rs
@@ -1,25 +1,6 @@
 use anchor_lang::prelude::*;
 use crate::{error::ManagerError, state::PATHFINDER_PROGRAM_ID};
-use crate::state::ManagerMarketConfig;
-use pathfinder::state::{Market, LenderShares, Config};
-use crate::state::ManagerVaultConfig;
-
-/// Loads a MarketConfig account from an AccountInfo
-/// Validates that the account is owned by the program
-// pub fn load_manager_market_config(ai: &AccountInfo) -> Result<ManagerMarketConfig> {
-//     // Verify the account is owned by the program
-//     require!(
-//         ai.owner.eq(&crate::ID),
-//         ManagerError::InvalidManagerMarketConfig
-//     );
-
-//     let market_config_data = ai.try_borrow_data()?;
-    
-//     // Deserialize the account data
-//     Ok(ManagerMarketConfig::deserialize(
-//         &mut &market_config_data.as_ref()[8..],
-//     )?)
-// }
+use pathfinder::state::Market;
 
 pub fn validate_manager_market_config_pda(
     ai: &Pubkey,

--- a/programs/assistant-to-the-regional-manager/src/utils/accounts.rs
+++ b/programs/assistant-to-the-regional-manager/src/utils/accounts.rs
@@ -1,76 +1,82 @@
 use anchor_lang::prelude::*;
-use crate::error::ManagerError;
-use crate::state::MarketConfig;
+use crate::{error::ManagerError, state::PATHFINDER_PROGRAM_ID};
+use crate::state::ManagerMarketConfig;
+use pathfinder::state::{Market, LenderShares, Config};
+use crate::state::ManagerVaultConfig;
 
 /// Loads a MarketConfig account from an AccountInfo
 /// Validates that the account is owned by the program
-pub fn load_market_config(ai: &AccountInfo) -> Result<MarketConfig> {
-    // Verify the account is owned by the program
-    require!(
-        ai.owner.eq(&crate::ID),
-        ManagerError::InvalidMarketConfig
-    );
+// pub fn load_manager_market_config(ai: &AccountInfo) -> Result<ManagerMarketConfig> {
+//     // Verify the account is owned by the program
+//     require!(
+//         ai.owner.eq(&crate::ID),
+//         ManagerError::InvalidManagerMarketConfig
+//     );
 
-    let market_config_data = ai.try_borrow_data()?;
+//     let market_config_data = ai.try_borrow_data()?;
     
-    // Deserialize the account data
-    Ok(MarketConfig::deserialize(
-        &mut &market_config_data.as_ref()[8..],
-    )?)
-}
+//     // Deserialize the account data
+//     Ok(ManagerMarketConfig::deserialize(
+//         &mut &market_config_data.as_ref()[8..],
+//     )?)
+// }
 
-/// Validates that a MarketConfig PDA matches expected values
-pub fn validate_market_config_pda(
-    ai: &AccountInfo,
-    config_key: &Pubkey,
-    market_pubkey: &Pubkey,
+pub fn validate_manager_market_config_pda(
+    ai: &Pubkey,
+    market: &Pubkey,
+    manager_config: &Pubkey,
 ) -> Result<()> {
-
-    // Derive the expected market config PDA
-    let seeds = &[
-        crate::state::MANAGER_MARKET_CONFIG_SEED_PREFIX,
-        config_key.as_ref(),
-        market_pubkey.as_ref(),
-    ];
-
-    let (expected_pda, _) = Pubkey::find_program_address(seeds, &crate::ID);
-
-    // Verify the account matches the expected PDA
-    require!(
-        ai.key() == expected_pda,
-        ManagerError::InvalidMarketConfig
+    let (expected_pda, _) = Pubkey::find_program_address(
+        &[
+            crate::state::MANAGER_MARKET_CONFIG_SEED_PREFIX,
+            manager_config.key().as_ref(),
+            market.key().as_ref(),
+        ],
+        &crate::ID
     );
 
-    // TODO: Inspect these bump values... they were not matching
-    // let (expected_market_config_pda, expected_bump) = Pubkey::find_program_address(seeds, ctx.program_id);
-    // if market_config.bump != expected_bump {
-    //   return err!(ManagerError::InvalidMarketConfig);
-    // }
-
+    require!(ai.key() == expected_pda, ManagerError::InvalidManagerMarketConfig);
     Ok(())
 }
 
 
+// Validates that a Market PDA matches expected values
+pub fn validate_pathfinder_market_pda(
+    ai: &Pubkey,
+    market: &Market,
+) -> Result<()> {
+    let expected_pda= Pubkey::create_program_address(
+        &[
+            pathfinder::state::MARKET_SEED_PREFIX,
+            market.quote_mint.key().as_ref(),
+            market.collateral_mint.key().as_ref(),
+            market.ltv_factor.to_le_bytes().as_ref(),
+            market.oracle.id.to_bytes().as_ref(),
+            &[market.bump]
+        ],
+        &PATHFINDER_PROGRAM_ID
+    ).map_err(|_| ManagerError::InvalidPathfinderMarketConfig)?;
+
+    require!(ai.key() == expected_pda, ManagerError::InvalidPathfinderMarketConfig);
+    Ok(())
+}
+
 // Validates that a MarketConfig PDA matches expected values
-// pub fn validate_pathfinder_market_pda(
-//     ai: &AccountInfo,
-//     market: &Market,
-// ) -> Result<()> {
+pub fn validate_pathfinder_lender_shares_pda(
+    market_info: &Pubkey,
+    manager_config_info: &Pubkey,
+    lender_shares_info: &Pubkey,
+) -> Result<()> {
 
-//     let seeds = &[
-//       pathfinder::state::MARKET_SEED_PREFIX,
-//       &market.quote_mint.key().as_ref(),
-//       &market.collateral_mint.key().as_ref(),
-//       &market.ltv_factor.to_le_bytes().as_ref(),
-//       &market.oracle.id.to_bytes().as_ref(),
-//     ];
+    let (expected_pda, _) = Pubkey::find_program_address(
+        &[
+            pathfinder::state::MARKET_SHARES_SEED_PREFIX,
+            market_info.key().as_ref(),
+            manager_config_info.key().as_ref(),
+        ],
+        &PATHFINDER_PROGRAM_ID
+    );
 
-//     let (expected_pda, _) = Pubkey::find_program_address(seeds, &crate::ID);
-
-//     require!(
-//         ai.key() == expected_pda,
-//         ManagerError::InvalidMarketConfig
-//     );  
-
-//     Ok(())
-// }
+    require!(lender_shares_info.key() == expected_pda, ManagerError::InvalidLenderShares);
+    Ok(())
+}

--- a/programs/pathfinder/src/instructions/deposit.rs
+++ b/programs/pathfinder/src/instructions/deposit.rs
@@ -90,14 +90,10 @@ impl<'info> Deposit<'info> {
     let mut shares = args.shares;
     let mut assets = args.amount;
 
-    msg!("shares: {}", shares);
-
     // Validate that either shares or assets must be specified, but not both
     if (shares == 0 && assets == 0) || (shares != 0 && assets != 0) {
       return err!(MarketError::AssetShareValueMismatch);
     }
-
-    msg!("depositing {}", assets);
 
     accrue_interest(market, config)?;
 

--- a/tests/fixtures/collateral.ts
+++ b/tests/fixtures/collateral.ts
@@ -24,6 +24,21 @@ export const ORACLE_CONFIG = {
     sb_id: "2o5GtpULRgktBvhHVVAjU6JZC5KNPagfgq8JfT85oVw5",
     decimals: 9,
   },
+  "PEPE": { // PEPE-USD
+    pyth_id: "0xd69731a2e74ac1ce884fc3890f7ee324b6deb66147055249568869ed700882e4",
+    sb_id: "CJ4iULr5vJaaYk9KBT3LihGHDrh282n9eouhmBxCH98Y",
+    decimals: 9,
+  },
+  "DOGE": { // DOGE-USD
+    pyth_id: "0xdcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c",
+    sb_id: "6sN3HsHMoBYngxjhAunaKdBKmPCzGah28xw2C7ufPfQs",
+    decimals: 9,
+  },
+  "WBTC": { // WBTC-USD
+    pyth_id: "0xc9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
+    sb_id: "6qmsMwtMmeqMgZEhyLv1Pe4wcqT5iKwJAWnmzmnKjf83",
+    decimals: 9,
+  },
 } as const;
 
 export type SupportedCollateral = keyof typeof ORACLE_CONFIG;

--- a/tests/fixtures/manager.ts
+++ b/tests/fixtures/manager.ts
@@ -493,21 +493,23 @@ export class ManagerFixture {
   }
 
 
-  async depositAssess({
+  async depositCustomCU({
     user,
     receiver,
     assets,
     markets,
+    customCU,
   }: {
     user: UserFixture;
     receiver: UserFixture;
     assets: anchor.BN;
     markets: MarketFixture[];
+    customCU: number;
   }): Promise<void> {
 
     let remainingAcc = deriveDepositRemainingAccounts(this.managerVaultConfigAcc.key, markets, this.program.programId);
     const budgetInstruction = ComputeBudgetProgram.setComputeUnitLimit({
-      units: 1_000_000,
+      units: customCU,
     });
 
     let tx = await this.program.methods

--- a/tests/fixtures/manager.ts
+++ b/tests/fixtures/manager.ts
@@ -1,4 +1,4 @@
-import { Keypair, PublicKey } from "@solana/web3.js";
+import { ComputeBudgetProgram, Keypair, PublicKey, sendAndConfirmTransaction, Transaction} from "@solana/web3.js";
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
 import { AssistantToTheRegionalManager } from "../../target/types/assistant_to_the_regional_manager";
@@ -493,7 +493,7 @@ export class ManagerFixture {
   }
 
 
-  async deposit({
+  async depositAssess({
     user,
     receiver,
     assets,
@@ -505,8 +505,55 @@ export class ManagerFixture {
     markets: MarketFixture[];
   }): Promise<void> {
 
-    // Check if pathfinder config is initialized
-    const pathfinderConfigData = await markets[0].get_config().get_data();
+    let remainingAcc = deriveDepositRemainingAccounts(this.managerVaultConfigAcc.key, markets, this.program.programId);
+    const budgetInstruction = ComputeBudgetProgram.setComputeUnitLimit({
+      units: 1_000_000,
+    });
+
+    let tx = await this.program.methods
+      .deposit({
+        assets,
+        receiver: receiver.key.publicKey,
+      })
+      .accounts({
+        user: user.key.publicKey,
+        config: this.managerVaultConfigAcc.key,
+        queue: this.queue.key,
+        feeRecipientShares: deriveSupplyShares(this.feeRecipient.key.publicKey, this.managerVaultConfigAcc.key, this.program.programId),
+        receiverShares: deriveSupplyShares(receiver.key.publicKey, this.managerVaultConfigAcc.key, this.program.programId),
+        pathfinderConfig: markets[0].get_config().key,
+        vaultAtaQuote: markets[0].quoteAta.key,
+        userAtaQuote: user.quoteAta,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+        pathfinderProgram: PATHFINDER_PROGRAM_ID,
+        // NOTE: remaining accounts are [market, lender_shares, market_config, ...]
+      })
+      .remainingAccounts(remainingAcc)
+      .transaction();
+    
+    
+    tx = tx.add(
+      budgetInstruction,
+    )
+    tx.recentBlockhash = this.provider.context.lastBlockhash
+    tx.sign(user.key.payer);
+
+    await this.provider.context.banksClient.processTransaction(tx);
+
+  }
+
+  async deposit({
+      user,
+      receiver,
+      assets,
+      markets,
+  }: {
+    user: UserFixture;
+    receiver: UserFixture;
+    assets: anchor.BN;
+    markets: MarketFixture[];
+  }): Promise < void> {
 
     let remainingAcc = deriveDepositRemainingAccounts(this.managerVaultConfigAcc.key, markets, this.program.programId);
 

--- a/tests/fixtures/manager.ts
+++ b/tests/fixtures/manager.ts
@@ -7,8 +7,8 @@ import { UserFixture, AccountFixture, splAccountFixture, queueAccountFixture, Ma
 import {
   COMMITMENT,
   deriveManagerConfigAccount,
-  deriveMarketConfigAccount,
-  deriveMultiMarketConfigs,
+  deriveManagerMarketConfigAccount,
+  deriveMultiManagerMarketConfigs,
   deriveQueueAccount,
   deriveAllocatorAccount,
   ONE_DAY_TIMELOCK,
@@ -276,7 +276,7 @@ export class ManagerFixture {
         systemProgram: anchor.web3.SystemProgram.programId,
         // NOTE: remaining accounts are market configs.
       })
-      .remainingAccounts(deriveMultiMarketConfigs(this.managerVaultConfigAcc.key, marketIds, this.program.programId))
+      .remainingAccounts(deriveMultiManagerMarketConfigs(this.managerVaultConfigAcc.key, marketIds, this.program.programId))
       .signers([user.key.payer])
       .rpc(COMMITMENT);
   }
@@ -527,7 +527,7 @@ export class ManagerFixture {
         systemProgram: anchor.web3.SystemProgram.programId,
         tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
         pathfinderProgram: PATHFINDER_PROGRAM_ID,
-        // NOTE: remaining accounts are [market, lender_shares, market_config, ...]
+        // NOTE: remaining accounts are [market, lender_shares, manager_market_config, ...]
       })
       .remainingAccounts(remainingAcc)
       .transaction();
@@ -536,11 +536,23 @@ export class ManagerFixture {
     tx = tx.add(
       budgetInstruction,
     )
-    tx.recentBlockhash = this.provider.context.lastBlockhash
+    tx.recentBlockhash = (await this.provider.context.banksClient.getLatestBlockhash())[0]
     tx.sign(user.key.payer);
+    tx.feePayer = user.key.publicKey;
+
+    // try {
+    //   let simTx = await this.provider.context.banksClient.simulateTransaction(tx, 'confirmed');
+    //   console.log("simTx logs:", simTx.meta.logMessages);
+    // } catch (error) {
+    //   console.error("Simulation error details:", {
+    //     error: error.message,
+    //     code: error.code,
+    //     logs: error.logs,
+    //     stack: error.stack
+    //   });
+    // }
 
     await this.provider.context.banksClient.processTransaction(tx);
-
   }
 
   async deposit({
@@ -556,6 +568,7 @@ export class ManagerFixture {
   }): Promise < void> {
 
     let remainingAcc = deriveDepositRemainingAccounts(this.managerVaultConfigAcc.key, markets, this.program.programId);
+    console.log("remainingAcc", remainingAcc);
 
     await this.program.methods
       .deposit({
@@ -574,7 +587,7 @@ export class ManagerFixture {
         systemProgram: anchor.web3.SystemProgram.programId,
         tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
         pathfinderProgram: PATHFINDER_PROGRAM_ID,
-        // NOTE: remaining accounts are [market, lender_shares, market_config, ...]
+        // NOTE: remaining accounts are [market, lender_shares, manager_market_config, ...]
       })
       .remainingAccounts(remainingAcc)
       .signers([user.key.payer])
@@ -583,8 +596,8 @@ export class ManagerFixture {
 
   public get_market_config(marketId: PublicKey): AccountFixture {
     return new AccountFixture(
-      "marketConfig",
-      deriveMarketConfigAccount(
+      "managerMarketConfig",
+      deriveManagerMarketConfigAccount(
         this.managerVaultConfigAcc.key,
         marketId,
         this.program.programId

--- a/tests/fixtures/manager.ts
+++ b/tests/fixtures/manager.ts
@@ -14,6 +14,8 @@ import {
   ONE_DAY_TIMELOCK,
   deriveDepositRemainingAccounts,
   PATHFINDER_PROGRAM_ID,
+  deriveLenderShares,
+  deriveSupplyShares,
 } from "../utils";
 
 export class ManagerFixture {
@@ -26,6 +28,7 @@ export class ManagerFixture {
   public allocator: AccountFixture;
   public queue: queueAccountFixture;
   public markets: MarketFixture[];
+  public feeRecipient: UserFixture;
 
   public constructor(
     public _program: Program<AssistantToTheRegionalManager>,
@@ -103,6 +106,8 @@ export class ManagerFixture {
       this.program
     );
 
+    this.feeRecipient = feeRecipient;
+
     await this.program.methods
       .createManager({
         symbol,
@@ -110,7 +115,7 @@ export class ManagerFixture {
         owner: owner.key.publicKey,
         guardian: guardian.key.publicKey,
         allocator: allocator.key.publicKey,
-        feeRecipient: feeRecipient.key.publicKey,
+        feeRecipient: this.feeRecipient.key.publicKey,
         skimRecipient: skimRecipient.key.publicKey,
         curator: curator.key.publicKey,
         timelock: ONE_DAY_TIMELOCK,
@@ -500,6 +505,11 @@ export class ManagerFixture {
     markets: MarketFixture[];
   }): Promise<void> {
 
+    // Check if pathfinder config is initialized
+    const pathfinderConfigData = await markets[0].get_config().get_data();
+
+    let remainingAcc = deriveDepositRemainingAccounts(this.managerVaultConfigAcc.key, markets, this.program.programId);
+
     await this.program.methods
       .deposit({
         assets,
@@ -508,16 +518,18 @@ export class ManagerFixture {
       .accounts({
         user: user.key.publicKey,
         config: this.managerVaultConfigAcc.key,
-        quoteAta: this.get_ata(this.quoteMint),
-        userAta: this.get_ata(this.quoteMint),
-        tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
-        systemProgram: anchor.web3.SystemProgram.programId,
-        pathfinderProgram: PATHFINDER_PROGRAM_ID,
+        queue: this.queue.key,
+        feeRecipientShares: deriveSupplyShares(this.feeRecipient.key.publicKey, this.managerVaultConfigAcc.key, this.program.programId),
+        receiverShares: deriveSupplyShares(receiver.key.publicKey, this.managerVaultConfigAcc.key, this.program.programId),
         pathfinderConfig: markets[0].get_config().key,
-        vaultAta: markets[0].get_ata(this.quoteMint),
+        vaultAtaQuote: markets[0].quoteAta.key,
+        userAtaQuote: user.quoteAta,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+        pathfinderProgram: PATHFINDER_PROGRAM_ID,
         // NOTE: remaining accounts are [market, lender_shares, market_config, ...]
       })
-      .remainingAccounts(deriveDepositRemainingAccounts(this.managerVaultConfigAcc.key, markets, this.program.programId))
+      .remainingAccounts(remainingAcc)
       .signers([user.key.payer])
       .rpc(COMMITMENT);
   }

--- a/tests/fixtures/market.ts
+++ b/tests/fixtures/market.ts
@@ -31,11 +31,16 @@ export class MarketFixture {
   ) {
     this.collateral = _collateral;
 
+    console.log("marketAcc oracle ID", this.collateral.getOracleId().toBase58());
+
     this.marketAcc = new marketAccountFixture(
       "market",
       deriveMarketAddress(_quoteMint, _collateralMint, this.collateral._ltvFactor, this.collateral.getOracleId(), _program.programId),
       _program,
     );
+
+    console.log("marketAcc:", this.marketAcc.key.toBase58());
+
     this.program = _program;
     this.provider = _provider;
     this.quoteMint = _quoteMint;
@@ -83,6 +88,19 @@ export class MarketFixture {
   }): Promise<void> {
 
     let source = this.collateral.getOracleSource() === OracleSource.PythPull ? { pythPull: {} } : { switchboardPull: {} }
+
+    console.log("Creating market with accounts:");
+    console.log("  user:", user.key.publicKey.toBase58());
+    console.log("  config:", get_config(this.program).key.toBase58());
+    console.log("  market:", this.marketAcc.key.toBase58());
+    console.log("  quoteMint:", quoteMint.toBase58());
+    console.log("  collateralMint:", collateralMint.toBase58());
+    console.log("  vaultAtaQuote:", vaultAtaQuote.toBase58());
+    console.log("  vaultAtaCollateral:", vaultAtaCollateral.toBase58());
+    console.log("  associatedTokenProgram:", anchor.utils.token.ASSOCIATED_PROGRAM_ID.toBase58());
+    console.log("  tokenProgram:", anchor.utils.token.TOKEN_PROGRAM_ID.toBase58());
+    console.log("  systemProgram:", anchor.web3.SystemProgram.programId.toBase58());
+
 
     await this.program.methods
       .createMarket({

--- a/tests/fixtures/market.ts
+++ b/tests/fixtures/market.ts
@@ -89,19 +89,6 @@ export class MarketFixture {
 
     let source = this.collateral.getOracleSource() === OracleSource.PythPull ? { pythPull: {} } : { switchboardPull: {} }
 
-    console.log("Creating market with accounts:");
-    console.log("  user:", user.key.publicKey.toBase58());
-    console.log("  config:", get_config(this.program).key.toBase58());
-    console.log("  market:", this.marketAcc.key.toBase58());
-    console.log("  quoteMint:", quoteMint.toBase58());
-    console.log("  collateralMint:", collateralMint.toBase58());
-    console.log("  vaultAtaQuote:", vaultAtaQuote.toBase58());
-    console.log("  vaultAtaCollateral:", vaultAtaCollateral.toBase58());
-    console.log("  associatedTokenProgram:", anchor.utils.token.ASSOCIATED_PROGRAM_ID.toBase58());
-    console.log("  tokenProgram:", anchor.utils.token.TOKEN_PROGRAM_ID.toBase58());
-    console.log("  systemProgram:", anchor.web3.SystemProgram.programId.toBase58());
-
-
     await this.program.methods
       .createMarket({
         oracleId: this.collateral.getOracleId(),

--- a/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
@@ -411,6 +411,267 @@ describe("deposit", () => {
     assert.equal(postManagerVaultDataDoge.shares.toNumber(), 50_000 * 1e9);
   });
 
+  it("successfully deposits accross six markets with fee and existing deposits", async () => {
+
+    // Should test worst case for computational units:
+    // Existing deposits in 6 markets
+    // fee calcualtions are required because of fee
+    // deposit accross all 6 markets happens successfully
+    // TODO: add fee
+
+    let marketConfigs = [
+    {
+      symbol: "SOL",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }, {
+      symbol: "WBTC",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }, {
+      symbol: "PEPE",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }, {
+      symbol: "DOGE",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }]
+    
+    const {
+      solMarket,
+      wbtcMarket,
+      pepeMarket,
+      dogeMarket,
+    } = await test.createMarkets(marketConfigs);
+
+    // initialize and create a market config
+    manager = await test.initManagerFixture([
+      market,
+      metaMarket,
+      solMarket,
+      wbtcMarket,
+      pepeMarket,
+      dogeMarket,
+    ]); 
+
+    await manager.create({
+      user: owen,
+      symbol: "USDCMBIG",
+      name: "USDC Manager Large",
+    });
+
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: solMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: wbtcMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: pepeMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    }); 
+    await manager.submitCap({
+      user: owen,
+      marketId: dogeMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    }); 
+
+
+    // pass 1 day + 1hr for timelock
+    await test.moveTimeForward(60 * 60 * 25);
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: solMarket.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: wbtcMarket.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: pepeMarket.marketAcc.key,
+    });
+ 
+    await manager.acceptCap({
+      user: owen,
+      marketId: dogeMarket.marketAcc.key,
+    });
+     
+    // Create supply queue with two markets
+    const supplyQueue = [
+      market.marketAcc.key,
+      metaMarket.marketAcc.key,
+      solMarket.marketAcc.key,
+      wbtcMarket.marketAcc.key,
+      pepeMarket.marketAcc.key,
+      dogeMarket.marketAcc.key,
+    ];
+
+    // Set the supply queue
+    await manager.setSupplyQueue({
+      user: owen,
+      marketIds: supplyQueue
+    })
+
+    // Verify queue was set correctly
+    const supplyQueueAccount = await manager.queue.getSupplyQueue();
+    assert.deepEqual(supplyQueueAccount, supplyQueue);
+
+    // Verify queue was set correctly
+    const withdrawQueueAccount= await manager.queue.getWithdrawQueue();
+    assert.deepEqual(withdrawQueueAccount, supplyQueue);
+
+
+    // should succeed because deposit amount is within summed supply caps
+    let depositAmount = new anchor.BN(550_000 * 1e9);
+
+    await manager.depositCustomCU({
+      user: dan,
+      receiver: dan,
+      markets: [market, metaMarket, solMarket, wbtcMarket, pepeMarket, dogeMarket],
+      assets: depositAmount,
+      customCU: 1_000_000,
+    });
+
+    // shared vault balance should be 100
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), depositAmount.toNumber());
+    assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
+
+    // Dan's balance should be reduced by deposit amount
+    assert.equal(Number(await dan.get_quo_balance()), 450_000 * 1e9);
+
+    // Verify last_total_assets was updated in config
+    const configData = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
+
+    // manager vault owns shares in base market
+    const postManagerVaultData = await market
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultData.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataMeta = await metaMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataMeta.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataSol = await solMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataSol.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataWbtc = await wbtcMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataWbtc.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataPepe = await pepeMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataPepe.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataDoge = await dogeMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataDoge.shares.toNumber(), 50_000 * 1e9);
+
+    // pass 1 day + 1hr for interest accrual
+    await test.moveTimeForward(60 * 60 * 25);
+
+    // should succeed because deposit amount is within summed supply caps
+    depositAmount = new anchor.BN(10_000 * 1e9);
+
+    await manager.depositCustomCU({
+      user: dan,
+      receiver: dan,
+      markets: [market, metaMarket, solMarket, wbtcMarket, pepeMarket, dogeMarket],
+      assets: depositAmount,
+      customCU: 1_000_000,
+    });
+
+    // shared vault balance should be 100
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), 560_000 * 1e9);
+
+    // Dan's balance should be reduced by deposit amount
+    assert.equal(Number(await dan.get_quo_balance()), 440_000 * 1e9);
+
+    // manager vault owns shares in base market
+    assert.equal(
+      (await market.get_lender_shares(manager.managerVaultConfigAcc.key).get_data()).shares.toNumber(),
+      100_000 * 1e9
+    );
+
+    assert.equal(
+      (await metaMarket.get_lender_shares(manager.managerVaultConfigAcc.key).get_data()).shares.toNumber(),
+      100_000 * 1e9
+    );
+
+    assert.equal(
+      (await solMarket.get_lender_shares(manager.managerVaultConfigAcc.key).get_data()).shares.toNumber(),
+      100_000 * 1e9
+    );
+
+    assert.equal(
+      (await wbtcMarket.get_lender_shares(manager.managerVaultConfigAcc.key).get_data()).shares.toNumber(),
+      100_000 * 1e9
+    );
+
+    assert.equal(
+      (await pepeMarket.get_lender_shares(manager.managerVaultConfigAcc.key).get_data()).shares.toNumber(),
+      100_000 * 1e9
+    );
+
+    assert.equal(
+      (await dogeMarket.get_lender_shares(manager.managerVaultConfigAcc.key).get_data()).shares.toNumber(),
+      59999448510994
+    );
+  });
+
   it("reverts when remaining accounts exceeds withdraw queue", async () => {
     // create one more market
     const wbtcMarket = await test.createMarket({

--- a/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
@@ -1,5 +1,5 @@
 import * as anchor from "@coral-xyz/anchor";
-import { ONE_DAY_TIMELOCK, TestUtils } from "../../utils";
+import { deriveSupplyShares, ONE_DAY_TIMELOCK, TestUtils } from "../../utils";
 import { ManagerFixture, MarketFixture, UserFixture } from "../../fixtures";
 import { AssistantToTheRegionalManager } from "../../../target/types/assistant_to_the_regional_manager";
 import assert from "assert";
@@ -26,7 +26,7 @@ describe("deposit", () => {
     );
 
     dan = await test.createUser(
-      new anchor.BN(1_000 * 1e9),
+      new anchor.BN(1_000_000 * 1e9),
       new anchor.BN(0)
     );
 
@@ -72,13 +72,13 @@ describe("deposit", () => {
     await manager.submitCap({
       user: owen,
       marketId: market.marketAcc.key,
-      supplyCap: new anchor.BN(1_000_000 * 1e9),
+      supplyCap: new anchor.BN(100_000 * 1e9),
     });
 
     await manager.submitCap({
       user: owen,
       marketId: metaMarket.marketAcc.key,
-      supplyCap: new anchor.BN(1_000_000 * 1e9),
+      supplyCap: new anchor.BN(100_000 * 1e9),
     });
 
     // pass 1 day + 1hr for timelock
@@ -107,12 +107,95 @@ describe("deposit", () => {
     })
 
     // Verify queue was set correctly
-    const queueAccount = await manager.queue.getSupplyQueue();
-    assert.deepEqual(queueAccount, supplyQueue);
+    const supplyQueueAccount = await manager.queue.getSupplyQueue();
+    assert.deepEqual(supplyQueueAccount, supplyQueue);
 
+    // Verify queue was set correctly
+    const withdrawQueueAccount= await manager.queue.getWithdrawQueue();
+    assert.deepEqual(withdrawQueueAccount, supplyQueue);
+
+    // initial balances
+    assert.equal(await dan.get_quo_balance(), 1_000_000 * 1e9); 
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), 0);
+    assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), 0);
   });
 
   it("successfully deposits", async () => {
+    const depositAmount = new anchor.BN(100 * 1e9);
 
+    await manager.deposit({
+      user: dan,
+      receiver: dan,
+      markets: [market, metaMarket],
+      assets: depositAmount,
+    });
+
+    // shared vault balance should be 100
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), depositAmount.toNumber());
+    assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
+
+    // Dan's balance should be reduced by deposit amount
+    assert.equal(await dan.get_quo_balance(), 999_900 * 1e9);
+
+    // Verify last_total_assets was updated in config
+    const configData = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
+
+    // manager vault owns shares in base market
+    const postManagerVaultData = await market
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultData.shares.toNumber(), depositAmount.toNumber());
+
+    // manager vault doesn't own shares in meta market
+    const postManagerVaultDataMeta = await metaMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataMeta, undefined);
+  }); 
+
+  it("successfully deposits accross two markets", async () => {
+    // const depositAmount = new anchor.BN(150_000 * 1e9);
+
+    // await manager.deposit({
+    //   user: dan,
+    //   receiver: dan,
+    //   markets: [market, metaMarket],
+    //   assets: depositAmount,
+    // });
+    // return;
+
+    // // shared vault balance should be 100
+    // assert.equal(Number(await market.quoteAta.getTokenBalance()), depositAmount.toNumber());
+    // assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
+
+    // // Dan's balance should be reduced by deposit amount
+    // assert.equal(await dan.get_quo_balance(), 900 * 1e9);
+
+    // // Verify last_total_assets was updated in config
+    // const configData = await manager.managerVaultConfigAcc.get_data();
+    // assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
+
+    // // manager vault owns shares in base market
+    // const postManagerVaultData = await market
+    //   .get_lender_shares(manager.managerVaultConfigAcc.key)
+    //   .get_data();
+    // assert.equal(postManagerVaultData.shares.toNumber(), depositAmount.toNumber());
+
+    // // manager vault doesn't own shares in meta market
+    // const postManagerVaultDataMeta = await metaMarket
+    //   .get_lender_shares(manager.managerVaultConfigAcc.key)
+    //   .get_data();
+    // assert.equal(postManagerVaultDataMeta, undefined);
   });
+
+  it("successfully deposits accross all 6 markets", async () => {
+  });
+
+  it("reverts when deposit exceeds supply cap", async () => {
+  });
+
+  it("reverts when remaining accounts exceeds withdraw queeu", async () => {
+  });
+
 });

--- a/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
@@ -157,11 +157,12 @@ describe("deposit", () => {
   it("successfully deposits accross two markets", async () => {
     const depositAmount = new anchor.BN(150_000 * 1e9);
 
-    await manager.depositAssess({
+    await manager.depositCustomCU({
       user: dan,
       receiver: dan,
       markets: [market, metaMarket],
       assets: depositAmount,
+      customCU: 1_000_000,
     });
 
     // shared vault balance should be 100
@@ -342,11 +343,12 @@ describe("deposit", () => {
     // should reject because deposit amount exceeds summed supply caps
     await assert.rejects(
       async () => {
-        await manager.depositAssess({
+        await manager.depositCustomCU({
           user: dan,
           receiver: dan,
           markets: [market, metaMarket, solMarket, wbtcMarket, pepeMarket, dogeMarket],
           assets: depositAmount,
+          customCU: 1_000_000,
         });
       },
       (err: any) => {
@@ -358,11 +360,12 @@ describe("deposit", () => {
     // should succeed because deposit amount is within summed supply caps
     depositAmount = new anchor.BN(550_000 * 1e9);
 
-    await manager.depositAssess({
+    await manager.depositCustomCU({
       user: dan,
       receiver: dan,
       markets: [market, metaMarket, solMarket, wbtcMarket, pepeMarket, dogeMarket],
       assets: depositAmount,
+      customCU: 1_000_000,
     });
 
     // shared vault balance should be 100
@@ -515,11 +518,12 @@ describe("deposit", () => {
     // fails with market not in queue error
     await assert.rejects(
       async () => {
-        await manager.depositAssess({
+        await manager.depositCustomCU({
           user: dan,
           receiver: dan,
           markets: [market, metaMarket, wbtcMarket],
           assets: depositAmount,
+          customCU: 1_000_000,
         });
       },
       (err: anchor.AnchorError) => {
@@ -532,11 +536,12 @@ describe("deposit", () => {
     // fails with duplicate markets at front of remaining accounts
     await assert.rejects(
       async () => {
-        await manager.depositAssess({
+        await manager.depositCustomCU({
           user: dan,
           receiver: dan,
           markets: [metaMarket, metaMarket, wbtcMarket],
           assets: depositAmount,
+          customCU: 1_000_000,
         });
       },
       (err: anchor.AnchorError) => {
@@ -548,11 +553,12 @@ describe("deposit", () => {
 
     await assert.rejects(
       async () => {
-        await manager.depositAssess({
+        await manager.depositCustomCU({
           user: dan,
           receiver: dan,
           markets: [metaMarket, wbtcMarket],
           assets: depositAmount,
+          customCU: 1_000_000,
         });
       },
       (err: anchor.AnchorError) => {
@@ -583,11 +589,12 @@ describe("deposit", () => {
     await test.moveTimeForward(1);
 
     // call deposit (pass two accounts)
-    await manager.depositAssess({
+    await manager.depositCustomCU({
       user: dan,
       receiver: dan,
       markets: [metaMarket, wbtcMarket],
       assets: depositAmount,
+      customCU: 1_000_000,
     });
 
     // shared vault balance should be 100

--- a/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
@@ -349,8 +349,7 @@ describe("deposit", () => {
           assets: depositAmount,
         });
       },
-      (err: anchor.AnchorError) => {
-        // not reading from rpc so we get back generic failure
+      (err: any) => {
         assert.strictEqual(err.code, "GenericFailure");
         return true;
       }
@@ -462,7 +461,7 @@ describe("deposit", () => {
       user: owen,
       marketId: metaMarket.marketAcc.key,
     });
-    
+
     await manager.acceptCap({
       user: owen,
       marketId: wbtcMarket.marketAcc.key,
@@ -596,19 +595,13 @@ describe("deposit", () => {
     assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
 
     // Dan's balance should be reduced by deposit amount
-    assert.equal(Number(await dan.get_quo_balance()), 450_000 * 1e9);
-    return;
+    assert.equal(Number(await dan.get_quo_balance()), 900_000 * 1e9);
 
     // Verify last_total_assets was updated in config
     const configData = await manager.managerVaultConfigAcc.get_data();
     assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
 
     // manager vault owns shares in base market
-    const postManagerVaultData = await market
-      .get_lender_shares(manager.managerVaultConfigAcc.key)
-      .get_data();
-    assert.equal(postManagerVaultData.shares.toNumber(), 100_000 * 1e9);
-
     const postManagerVaultDataMeta = await metaMarket
       .get_lender_shares(manager.managerVaultConfigAcc.key)
       .get_data();

--- a/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
@@ -121,7 +121,7 @@ describe("deposit", () => {
   });
 
   it("successfully deposits", async () => {
-    const depositAmount = new anchor.BN(100 * 1e9);
+    const depositAmount = new anchor.BN(1_000 * 1e9);
 
     await manager.deposit({
       user: dan,
@@ -135,7 +135,7 @@ describe("deposit", () => {
     assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
 
     // Dan's balance should be reduced by deposit amount
-    assert.equal(await dan.get_quo_balance(), 999_900 * 1e9);
+    assert.equal(await dan.get_quo_balance(), 999_000 * 1e9);
 
     // Verify last_total_assets was updated in config
     const configData = await manager.managerVaultConfigAcc.get_data();
@@ -155,47 +155,465 @@ describe("deposit", () => {
   }); 
 
   it("successfully deposits accross two markets", async () => {
-    // const depositAmount = new anchor.BN(150_000 * 1e9);
+    const depositAmount = new anchor.BN(150_000 * 1e9);
 
-    // await manager.deposit({
-    //   user: dan,
-    //   receiver: dan,
-    //   markets: [market, metaMarket],
-    //   assets: depositAmount,
-    // });
-    // return;
+    await manager.depositAssess({
+      user: dan,
+      receiver: dan,
+      markets: [market, metaMarket],
+      assets: depositAmount,
+    });
 
-    // // shared vault balance should be 100
-    // assert.equal(Number(await market.quoteAta.getTokenBalance()), depositAmount.toNumber());
-    // assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
+    // shared vault balance should be 100
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), depositAmount.toNumber());
+    assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
 
-    // // Dan's balance should be reduced by deposit amount
-    // assert.equal(await dan.get_quo_balance(), 900 * 1e9);
+    // Dan's balance should be reduced by deposit amount
+    assert.equal(Number(await dan.get_quo_balance()), 850_000 * 1e9);
 
-    // // Verify last_total_assets was updated in config
-    // const configData = await manager.managerVaultConfigAcc.get_data();
-    // assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
+    // Verify last_total_assets was updated in config
+    const configData = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
 
-    // // manager vault owns shares in base market
-    // const postManagerVaultData = await market
-    //   .get_lender_shares(manager.managerVaultConfigAcc.key)
-    //   .get_data();
-    // assert.equal(postManagerVaultData.shares.toNumber(), depositAmount.toNumber());
+    // manager vault owns shares in base market
+    const postManagerVaultData = await market
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultData.shares.toNumber(), 100_000 * 1e9);
 
-    // // manager vault doesn't own shares in meta market
-    // const postManagerVaultDataMeta = await metaMarket
-    //   .get_lender_shares(manager.managerVaultConfigAcc.key)
-    //   .get_data();
-    // assert.equal(postManagerVaultDataMeta, undefined);
+    const postManagerVaultDataMeta = await metaMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataMeta.shares.toNumber(), 50_000 * 1e9);
   });
 
-  it("successfully deposits accross all 6 markets", async () => {
+  it("successfully deposits accross six markets", async () => {
+
+    let marketConfigs = [
+    {
+      symbol: "SOL",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }, {
+      symbol: "WBTC",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }, {
+      symbol: "PEPE",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }, {
+      symbol: "DOGE",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy, 
+    }]
+    
+    const {
+      solMarket,
+      wbtcMarket,
+      pepeMarket,
+      dogeMarket,
+    } = await test.createMarkets(marketConfigs);
+
+    // initialize and create a market config
+    manager = await test.initManagerFixture([
+      market,
+      metaMarket,
+      solMarket,
+      wbtcMarket,
+      pepeMarket,
+      dogeMarket,
+    ]); 
+
+    await manager.create({
+      user: owen,
+      symbol: "USDCMBIG",
+      name: "USDC Manager Large",
+    });
+
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: solMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: wbtcMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: pepeMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    }); 
+    await manager.submitCap({
+      user: owen,
+      marketId: dogeMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    }); 
+
+
+    // pass 1 day + 1hr for timelock
+    await test.moveTimeForward(60 * 60 * 25);
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: solMarket.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: wbtcMarket.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: pepeMarket.marketAcc.key,
+    });
+ 
+    await manager.acceptCap({
+      user: owen,
+      marketId: dogeMarket.marketAcc.key,
+    });
+     
+    // Create supply queue with two markets
+    const supplyQueue = [
+      market.marketAcc.key,
+      metaMarket.marketAcc.key,
+      solMarket.marketAcc.key,
+      wbtcMarket.marketAcc.key,
+      pepeMarket.marketAcc.key,
+      dogeMarket.marketAcc.key,
+    ];
+
+    // Set the supply queue
+    await manager.setSupplyQueue({
+      user: owen,
+      marketIds: supplyQueue
+    })
+
+    // Verify queue was set correctly
+    const supplyQueueAccount = await manager.queue.getSupplyQueue();
+    assert.deepEqual(supplyQueueAccount, supplyQueue);
+
+    // Verify queue was set correctly
+    const withdrawQueueAccount= await manager.queue.getWithdrawQueue();
+    assert.deepEqual(withdrawQueueAccount, supplyQueue);
+
+    // deposit 601_000 accross all 6 markets
+    let depositAmount = new anchor.BN(601_000 * 1e9);
+
+    // should reject because deposit amount exceeds summed supply caps
+    await assert.rejects(
+      async () => {
+        await manager.depositAssess({
+          user: dan,
+          receiver: dan,
+          markets: [market, metaMarket, solMarket, wbtcMarket, pepeMarket, dogeMarket],
+          assets: depositAmount,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        // not reading from rpc so we get back generic failure
+        assert.strictEqual(err.code, "GenericFailure");
+        return true;
+      }
+    );
+
+    // should succeed because deposit amount is within summed supply caps
+    depositAmount = new anchor.BN(550_000 * 1e9);
+
+    await manager.depositAssess({
+      user: dan,
+      receiver: dan,
+      markets: [market, metaMarket, solMarket, wbtcMarket, pepeMarket, dogeMarket],
+      assets: depositAmount,
+    });
+
+    // shared vault balance should be 100
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), depositAmount.toNumber());
+    assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
+
+    // Dan's balance should be reduced by deposit amount
+    assert.equal(Number(await dan.get_quo_balance()), 450_000 * 1e9);
+
+    // Verify last_total_assets was updated in config
+    const configData = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
+
+    // manager vault owns shares in base market
+    const postManagerVaultData = await market
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultData.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataMeta = await metaMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataMeta.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataSol = await solMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataSol.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataWbtc = await wbtcMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataWbtc.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataPepe = await pepeMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataPepe.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataDoge = await dogeMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataDoge.shares.toNumber(), 50_000 * 1e9);
   });
 
-  it("reverts when deposit exceeds supply cap", async () => {
-  });
+  it("reverts when remaining accounts exceeds withdraw queue", async () => {
+    // create one more market
+    const wbtcMarket = await test.createMarket({
+      symbol: "WBTC",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      feeRecipient: futarchy,
+      authority: futarchy,
+    });
 
-  it("reverts when remaining accounts exceeds withdraw queeu", async () => {
+    // initialize and create a market config
+    manager = await test.initManagerFixture([
+      market,
+      metaMarket,
+      wbtcMarket,
+    ]);
+
+    await manager.create({
+      user: owen,
+      symbol: "USDCMEDIUM",
+      name: "USDC Manager Medium",
+    });
+
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+    await manager.submitCap({
+      user: owen,
+      marketId: wbtcMarket.marketAcc.key,
+      supplyCap: new anchor.BN(100_000 * 1e9),
+    });
+
+    // pass 1 day + 1hr for timelock
+    await test.moveTimeForward(60 * 60 * 25);
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+    });
+    
+    await manager.acceptCap({
+      user: owen,
+      marketId: wbtcMarket.marketAcc.key,
+    });
+
+    // Create supply queue with threemarkets
+    const supplyQueue = [
+      market.marketAcc.key,
+      metaMarket.marketAcc.key,
+      wbtcMarket.marketAcc.key,
+    ];
+
+    // Set the supply queue
+    await manager.setSupplyQueue({
+      user: owen,
+      marketIds: supplyQueue
+    })
+
+    // Verify queue was set correctly
+    const supplyQueueAccount = await manager.queue.getSupplyQueue();
+    assert.deepEqual(supplyQueueAccount, supplyQueue);
+
+    // Verify queue was set correctly
+    const withdrawQueueAccount= await manager.queue.getWithdrawQueue();
+    assert.deepEqual(withdrawQueueAccount, supplyQueue);
+
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(0 * 1e9),
+    });
+
+    // remove one from withdraw queue
+    await manager.removeFromWithdrawQueue({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
+
+    // Verify queue differences
+    const withdrawQueueAccountAfterRemove= await manager.queue.getWithdrawQueue();
+    assert.deepEqual(withdrawQueueAccountAfterRemove, [
+      metaMarket.marketAcc.key,
+      wbtcMarket.marketAcc.key,
+    ]);
+
+    const supplyQueueAccountAfterRemove= await manager.queue.getSupplyQueue();
+    assert.deepEqual(supplyQueueAccountAfterRemove, supplyQueue);
+
+    let depositAmount = new anchor.BN(100_000 * 1e9);
+
+    // fails with market not in queue error
+    await assert.rejects(
+      async () => {
+        await manager.depositAssess({
+          user: dan,
+          receiver: dan,
+          markets: [market, metaMarket, wbtcMarket],
+          assets: depositAmount,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        // fails with market not in queue error
+        assert.strictEqual(err.code, "GenericFailure");
+        return true;
+      }
+    );
+
+    // fails with duplicate markets at front of remaining accounts
+    await assert.rejects(
+      async () => {
+        await manager.depositAssess({
+          user: dan,
+          receiver: dan,
+          markets: [metaMarket, metaMarket, wbtcMarket],
+          assets: depositAmount,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        // invalid supply queue account
+        assert.strictEqual(err.code, "GenericFailure");
+        return true;
+      }
+    );
+
+    await assert.rejects(
+      async () => {
+        await manager.depositAssess({
+          user: dan,
+          receiver: dan,
+          markets: [metaMarket, wbtcMarket],
+          assets: depositAmount,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        // invalid supply queue account -> because markets are not in supply queue order
+        assert.strictEqual(err.code, "GenericFailure");
+        return true;
+      }
+    );
+
+    // set new supply queue
+    await manager.setSupplyQueue({
+      user: owen,
+      marketIds: [metaMarket.marketAcc.key, wbtcMarket.marketAcc.key],
+    });
+
+    // Verify queue was set correctly
+    const supplyQueueAccountAfterSet= await manager.queue.getSupplyQueue();
+    assert.deepEqual(supplyQueueAccountAfterSet, [
+      metaMarket.marketAcc.key,
+      wbtcMarket.marketAcc.key,
+    ]);
+
+    // Verify queue simularities
+    const withdrawQueueAccountAfterSet= await manager.queue.getWithdrawQueue();
+    assert.deepEqual(withdrawQueueAccountAfterSet, supplyQueueAccountAfterSet);
+
+    // pass 1 day + 1hr for timelock
+    await test.moveTimeForward(1);
+
+    // call deposit (pass two accounts)
+    await manager.depositAssess({
+      user: dan,
+      receiver: dan,
+      markets: [metaMarket, wbtcMarket],
+      assets: depositAmount,
+    });
+
+    // shared vault balance should be 100
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), depositAmount.toNumber());
+    assert.equal(Number(await metaMarket.quoteAta.getTokenBalance()), depositAmount.toNumber());
+
+    // Dan's balance should be reduced by deposit amount
+    assert.equal(Number(await dan.get_quo_balance()), 450_000 * 1e9);
+    return;
+
+    // Verify last_total_assets was updated in config
+    const configData = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(configData.lastTotalAssets.toNumber(), depositAmount.toNumber());
+
+    // manager vault owns shares in base market
+    const postManagerVaultData = await market
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultData.shares.toNumber(), 100_000 * 1e9);
+
+    const postManagerVaultDataMeta = await metaMarket
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultDataMeta.shares.toNumber(), 100_000 * 1e9);
+
   });
 
 });

--- a/tests/user-actions/assistant-to-the-regional-manager/guardian.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/guardian.ts
@@ -175,10 +175,6 @@ describe("guardian", () => {
       supplyCap: new anchor.BN(1000),
     });
 
-    // Verify market config state after submit
-    const marketConfigAfterSubmit = await manager.get_market_config(market.marketAcc.key).get_data();
-    assert.equal(marketConfigAfterSubmit.pendingCap.value.toNumber(), 1000);
-    assert.equal(marketConfigAfterSubmit.pendingCap.validAt.toNumber(), await test.getTime() + ONE_DAY_TIMELOCK.toNumber());
 
     // Move time forward but not past timelock
     await test.moveTimeForward(ONE_DAY_TIMELOCK.toNumber() / 2);
@@ -194,8 +190,6 @@ describe("guardian", () => {
     assert.equal(marketConfig.cap.toNumber(), 0); // Original cap
     assert.equal(marketConfig.enabled, false);
     assert.equal(marketConfig.removableAt.toNumber(), 0);
-    assert.equal(marketConfig.pendingCap.value.toNumber(), 0);
-    assert.equal(marketConfig.pendingCap.validAt.toNumber(), 0);
   });
 
   it("guardian can revoke pending guardian", async () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -330,6 +330,33 @@ export class TestUtils {
       .rpc();
   }
 
+  public async createMarkets(
+      marketConfigs: {
+        symbol: string,
+        ltvFactor: anchor.BN,
+        price: anchor.BN,
+        conf: anchor.BN,
+        expo: number,
+        feeRecipient: UserFixture,
+        authority: UserFixture,
+      }[],
+  ): Promise<{
+    solMarket?: MarketFixture,
+    wbtcMarket?: MarketFixture,
+    pepeMarket?: MarketFixture,
+    dogeMarket?: MarketFixture,
+    metaMarket?: MarketFixture
+  }> {
+    const markets: {[key: string]: MarketFixture} = {};
+    for (const marketConfig of marketConfigs) {
+      const market = await this.createMarket(marketConfig);
+      const marketKey = `${marketConfig.symbol.toLowerCase()}Market`;
+      markets[marketKey] = market;
+    }
+    return markets;
+  }
+
+
   public async createMarket(
     {
       symbol,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -130,7 +130,7 @@ export function deriveDepositRemainingAccounts(
   markets: MarketFixture[],
   programId: PublicKey
 ) {
-  // NOTE: remaining accounts are [market, lender_shares, market_config, ...]
+  // NOTE: remaining accounts are [market, lender_shares, manager_market_config, ...]
   const remainingAccounts = markets.map((market) => [
     {
       pubkey: market.marketAcc.key,
@@ -143,7 +143,7 @@ export function deriveDepositRemainingAccounts(
       isWritable: true
     },
     {
-      pubkey: deriveMarketConfigAccount(
+      pubkey: deriveManagerMarketConfigAccount(
         managerConfig,
         market.marketAcc.key,
         programId
@@ -156,14 +156,14 @@ export function deriveDepositRemainingAccounts(
   return remainingAccounts;
 }
 
-export function deriveMultiMarketConfigs(
+export function deriveMultiManagerMarketConfigs(
   managerConfig: PublicKey,
   marketIds: PublicKey[],
   programId: PublicKey
 ) {
   const marketConfigs = marketIds.map((marketId) => {
     return {
-      pubkey: deriveMarketConfigAccount(
+      pubkey: deriveManagerMarketConfigAccount(
         managerConfig,
         marketId,
         programId
@@ -176,7 +176,7 @@ export function deriveMultiMarketConfigs(
   return marketConfigs;
 }
 
-export function deriveMarketConfigAccount(
+export function deriveManagerMarketConfigAccount(
   managerConfig: PublicKey,
   marketId: PublicKey,
   programId: PublicKey

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -31,13 +31,15 @@ export function create_account_w_sol(
   pubkey: PublicKey,
   sol_amount: number,
   data: Buffer = Buffer.alloc(0),
+  rentEpoch: number = 0
 ) {
   create_custom_account(
     context,
     pubkey,
     anchor.web3.SystemProgram.programId,
     LAMPORTS_PER_SOL * sol_amount,
-    data
+    data,
+    rentEpoch
   );
 }
 
@@ -91,6 +93,21 @@ export function deriveMarketAddress(
   )[0];
 }
 
+export function deriveSupplyShares(
+  userKey: PublicKey,
+  config: PublicKey,
+  programId: PublicKey
+): PublicKey {
+    return PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("managershares"),
+        config.toBuffer(),
+        userKey.toBuffer(),
+      ],
+      programId
+    )[0];
+  }
+
 export function deriveManagerConfigAccount(
   quoteMint: PublicKey,
   symbol: string,
@@ -118,12 +135,12 @@ export function deriveDepositRemainingAccounts(
     {
       pubkey: market.marketAcc.key,
       isSigner: false,
-      isWritable: false
+      isWritable: true
     },
     {
       pubkey: market.get_lender_shares(managerConfig).key,
       isSigner: false, 
-      isWritable: false
+      isWritable: true
     },
     {
       pubkey: deriveMarketConfigAccount(


### PR DESCRIPTION
- changed manager's `MarketConfig` -> `ManagerMarketConfig` better naming
- Added `deposit()` method
  - Remaining accounts are ordered by supply queue (then any excess accounts which exceed `supplyQueue.len()` are required in the `withdrawQueue`
  - Remaining accounts are in threes: [market, lender_shares, manager_market_config, ...]