### PR TITLE
new fee recipients can now be set

### DIFF
--- a/programs/assistant-to-the-regional-manager/src/instructions/create_manager.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/create_manager.rs
@@ -54,6 +54,19 @@ pub struct CreateManager<'info> {
   )]
   pub queue: Box<Account<'info, QueueState>>,
 
+  #[account(
+      init,
+      payer = user,
+      space = 8 + std::mem::size_of::<SupplyShares>(),
+      seeds = [
+          MANAGER_SHARES_SEED_PREFIX,
+          config.key().as_ref(),
+          args.fee_recipient.key().as_ref()
+      ],
+      bump
+  )]
+  pub fee_recipient_shares: Account<'info, SupplyShares>,
+
   #[account(constraint = quote_mint.is_initialized == true)]
   pub quote_mint: Box<Account<'info, Mint>>,
 
@@ -70,6 +83,7 @@ impl<'info> CreateManager<'info> {
       config,
       quote_mint,
       queue,
+      fee_recipient_shares,
       ..
     } = ctx.accounts;
 
@@ -105,6 +119,11 @@ impl<'info> CreateManager<'info> {
       bump: ctx.bumps.queue,
       supply_queue: Vec::new(),
       withdraw_queue: Vec::new(),
+    });
+
+    fee_recipient_shares.set_inner(SupplyShares {
+      bump: ctx.bumps.fee_recipient_shares,
+      shares: 0,
     });
 
     Ok(())

--- a/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/deposit.rs
@@ -49,17 +49,14 @@ pub struct Deposit<'info> {
     )]
     pub queue: Box<Account<'info, QueueState>>,
     
-    // TODO: initialize in where ever we set fee_recipient
     #[account(
-        init_if_needed,
-        payer = user,
-        space = 8 + std::mem::size_of::<SupplyShares>(),
+        mut,
         seeds = [
             MANAGER_SHARES_SEED_PREFIX,
             config.key().as_ref(),
             config.fee_recipient.key().as_ref()
         ],
-        bump
+        bump = fee_recipient_shares.bump,
     )]
     pub fee_recipient_shares: Account<'info, SupplyShares>,
 

--- a/programs/assistant-to-the-regional-manager/src/instructions/mod.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/mod.rs
@@ -12,6 +12,7 @@ pub mod timelock;
 pub mod submit_market_removal;
 pub mod deposit;
 pub mod set_fee;
+pub mod set_fee_recipient;
 
 pub use create_manager::*;
 pub use set_supply_queue::*;
@@ -27,3 +28,4 @@ pub use timelock::*;
 pub use submit_market_removal::*;
 pub use deposit::*;
 pub use set_fee::*;
+pub use set_fee_recipient::*;

--- a/programs/assistant-to-the-regional-manager/src/instructions/set_fee_recipient.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/set_fee_recipient.rs
@@ -11,13 +11,13 @@ use pathfinder::{
 };
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
-pub struct SetFeeArgs {
-    pub fee: u64,
+pub struct SetFeeRecipientArgs {
+    pub new_fee_recipient: Pubkey,
 }
 
 #[derive(Accounts)]
-#[instruction(args: SetFeeArgs)]
-pub struct SetFee<'info> {
+#[instruction(args: SetFeeRecipientArgs)]
+pub struct SetFeeRecipient<'info> {
     #[account(mut)]
     pub user: Signer<'info>,
 
@@ -43,6 +43,20 @@ pub struct SetFee<'info> {
         bump = fee_recipient_shares.bump,
     )]
     pub fee_recipient_shares: Account<'info, SupplyShares>,
+
+    // new fee recipient is always expected to show up with a new / fresh account
+    #[account(
+        init,
+        payer = user,
+        space = 8 + std::mem::size_of::<SupplyShares>(),
+        seeds = [
+            MANAGER_SHARES_SEED_PREFIX,
+            config.key().as_ref(),
+            args.new_fee_recipient.key().as_ref()
+        ],
+        bump
+    )]
+    pub new_fee_recipient_shares: Account<'info, SupplyShares>,
     
     #[account(
         mut,
@@ -67,33 +81,34 @@ pub struct SetFee<'info> {
     // Any excess accounts which exist in the withdraw queue but not in supply queue are tacked onto the end
 }
 
-impl<'info> OwnerProtection<'info> for SetFee<'info> {}
-impl<'info, 'c: 'info> VaultAccounting<'info, 'c> for SetFee<'info> {}
+impl<'info> OwnerProtection<'info> for SetFeeRecipient<'info> {}
+impl<'info, 'c: 'info> VaultAccounting<'info, 'c> for SetFeeRecipient<'info> {}
 
-impl<'info, 'c: 'info> SetFee<'info> {
+impl<'info, 'c: 'info> SetFeeRecipient<'info> {
 
-    pub fn validate(&self, args: &SetFeeArgs) -> Result<()> {
+    pub fn validate(&self, args: &SetFeeRecipientArgs) -> Result<()> {
         self.is_owner(&self.user, &self.config)?;
 
-        if args.fee == self.config.fee {
+        if args.new_fee_recipient == self.config.fee_recipient {
             return err!(ManagerError::AlreadySet);
         }
 
-        if args.fee > MAX_FEE {
-            return err!(ManagerError::MaxFeeExceeded);
+        if args.new_fee_recipient == Pubkey::default() {
+            return err!(ManagerError::ZeroFeeRecipient);
         }
 
-        if args.fee != 0 && self.config.fee_recipient == Pubkey::default() {
+        if self.config.fee != 0 && self.config.fee_recipient == Pubkey::default() {
             return err!(ManagerError::ZeroFeeRecipient);
         }
 
         Ok(())
     }
 
-    pub fn handle(ctx: Context<'_, '_, 'c, 'info, Self>, args: SetFeeArgs) -> Result<()> {
-        let SetFee { 
+    pub fn handle(ctx: Context<'_, '_, 'c, 'info, Self>, args: SetFeeRecipientArgs) -> Result<()> {
+        let SetFeeRecipient { 
             config,
             fee_recipient_shares,
+            new_fee_recipient_shares,
             queue,
             pathfinder_config,
             pathfinder_program ,
@@ -119,7 +134,13 @@ impl<'info, 'c: 'info> SetFee<'info> {
             .checked_add(new_total_assets)
             .ok_or(ManagerError::MathOverflow)?;
 
-        config.fee = args.fee;
+        // initialize recipient shares
+        new_fee_recipient_shares.set_inner(SupplyShares {
+            bump: ctx.bumps.new_fee_recipient_shares,
+            shares: 0,
+        });
+
+        config.fee_recipient = args.new_fee_recipient;
 
         Ok(())
     }

--- a/programs/assistant-to-the-regional-manager/src/lib.rs
+++ b/programs/assistant-to-the-regional-manager/src/lib.rs
@@ -27,6 +27,14 @@ pub mod assistant_to_the_regional_manager {
     }
 
     #[access_control(ctx.accounts.validate(&args))]
+    pub fn set_fee_recipient<'c: 'info, 'info>(
+        ctx: Context<'_, '_, 'c, 'info, SetFeeRecipient<'info>>,
+        args: SetFeeRecipientArgs
+    ) -> Result<()> {
+        SetFeeRecipient::handle(ctx, args)
+    }
+
+    #[access_control(ctx.accounts.validate(&args))]
     pub fn submit_cap(ctx: Context<SubmitCap>, args: SubmitCapArgs) -> Result<()> {
         SubmitCap::handle(ctx, args)
     }

--- a/tests/fixtures/manager.ts
+++ b/tests/fixtures/manager.ts
@@ -133,6 +133,38 @@ export class ManagerFixture {
       .rpc();
   }
 
+  async setFeeRecipient({
+    user,
+    new_fee_recipient,
+    markets,
+  }: {
+    user: UserFixture;
+    new_fee_recipient: UserFixture;
+    markets: MarketFixture[];
+  }): Promise<void> {
+
+    let remainingAcc = deriveDepositRemainingAccounts(this.managerVaultConfigAcc.key, markets, this.program.programId);
+
+    await this.program.methods
+      .setFeeRecipient({
+        newFeeRecipient: new_fee_recipient.key.publicKey
+      })
+      .accounts({
+        user: user.key.publicKey,
+        config: this.managerVaultConfigAcc.key,
+        queue: this.queue.key,
+        feeRecipientShares: deriveSupplyShares(this.feeRecipient.key.publicKey, this.managerVaultConfigAcc.key, this.program.programId),
+        newFeeRecipientShares: deriveSupplyShares(new_fee_recipient.key.publicKey, this.managerVaultConfigAcc.key, this.program.programId),
+        pathfinderConfig: markets[0].get_config().key,
+        pathfinderProgram: PATHFINDER_PROGRAM_ID,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        // NOTE: remaining accounts are [market, lender_shares, manager_market_config, ...]
+      })
+      .remainingAccounts(remainingAcc)
+      .signers([user.key.payer])
+      .rpc(COMMITMENT); 
+  }
+
   async setFee({
     user,
     fee,

--- a/tests/user-actions/assistant-to-the-regional-manager/fee.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/fee.ts
@@ -10,6 +10,7 @@ describe("set_fee", () => {
   let manager: ManagerFixture;
   let owen: UserFixture;
   let bob: UserFixture;
+  let fred: UserFixture;
   let futarchy: UserFixture;
   let market: MarketFixture;
 
@@ -26,6 +27,11 @@ describe("set_fee", () => {
     bob = await test.createUser(
       new anchor.BN(1_000 * 1e9),
       new anchor.BN(1_000 * 1e9)
+    );
+
+    fred = await test.createUser(
+      new anchor.BN(100_000 * 1e9),
+      new anchor.BN(0)
     );
 
     futarchy = await test.createUser(
@@ -175,4 +181,21 @@ describe("set_fee", () => {
       }
     );
   });
+
+  it("successfully sets new fee recipient", async () => {
+
+    const config = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(config.feeRecipient.toBase58(), owen.key.publicKey.toBase58());
+
+    await manager.setFeeRecipient({
+      user: owen,
+      new_fee_recipient: fred,
+      markets: [market]
+    })
+
+    const postConfig = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(postConfig.feeRecipient.toBase58(), fred.key.publicKey.toBase58());
+
+  });
+
 });


### PR DESCRIPTION
- `fee_recipient_shares` account is now initialized in `createManager()` and `setFeeRecipient()` instructions
- used in:
  - `deposit()`
  - `setFee()`