### PR TITLE
re-added queue tests, refactored and fixed removeFromWithdrawQueue

### DIFF
--- a/programs/assistant-to-the-regional-manager/src/error.rs
+++ b/programs/assistant-to-the-regional-manager/src/error.rs
@@ -114,4 +114,13 @@ pub enum ManagerError {
 
     #[msg("Exceeded max withdraw")]
     ExceededMaxWithdraw,
+
+    #[msg("Invalid account owner")]
+    InvalidAccountOwner,
+
+    #[msg("Invalid seeds")]
+    InvalidSeeds,
+
+    #[msg("Invalid account data")]
+    InvalidAccountData,
 }

--- a/programs/assistant-to-the-regional-manager/src/instructions/remove_from_withdraw_queue.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/remove_from_withdraw_queue.rs
@@ -1,11 +1,21 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::*;
-use pathfinder::state::LenderShares;
 
 use crate::state::*;
 use crate::error::*;
 
+use pathfinder::{
+  cpi::{
+    init_lender_shares,
+    accounts::InitLenderShares
+  },
+  state::{Market, LenderShares, Config, MARKET_SHARES_SEED_PREFIX},
+  program::Pathfinder,
+};
+
 use crate::traits::allocator::AllocatorProtection;
+
+use pathfinder::instructions::init_lender_shares::*;
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct RemoveFromWithdrawQueueArgs {
@@ -62,9 +72,13 @@ pub struct RemoveFromWithdrawQueue<'info> {
     )]
     pub queue: Box<Account<'info, QueueState>>,
 
-    // TODO: if I can't derive this account since its owned by pathfinder
-    // how do I ensure this is the right lender_shares account?
-    pub lender_shares: Option<Account<'info, LenderShares>>,
+    // pathfinder accounts
+    /// CHECK this account must be passed but could be uninitialized
+    #[account(mut)]
+    pub lender_shares: AccountInfo<'info>,
+    pub pathfinder_market: Box<Account<'info, Market>>,
+    pub pathfinder_config: Box<Account<'info, Config>>,
+    pub pathfinder_program: Program<'info, Pathfinder>,
 
     #[account(constraint = quote_mint.is_initialized == true)]
     pub quote_mint: Box<Account<'info, Mint>>,
@@ -84,50 +98,129 @@ impl<'info> RemoveFromWithdrawQueue<'info> {
   }
 
   pub fn handle(ctx: Context<RemoveFromWithdrawQueue>, args: RemoveFromWithdrawQueueArgs) -> Result<()> {
-    let RemoveFromWithdrawQueue {
-      queue,
-      market_config,
-      lender_shares,
-      ..
-    } = ctx.accounts;
+    let accounts = ctx.accounts;
+    
+    // Find and validate market position
+    let market_index = Self::find_market_in_queue(&accounts.queue, &args.market_id)?;
+    
+    // Validate market removal conditions
+    Self::validate_market_removal_conditions(&accounts.market_config)?;
+    
+    // Get lender shares (initialize if needed)
+    let shares: u64 = Self::get_initialize_lender_shares(&accounts)?;
+    
+    // Validate position removal conditions
+    Self::validate_position_removal_conditions(&accounts.market_config, shares)?;
 
-    // Find position of market to remove
-    for i in 0..queue.withdraw_queue.len() {
-      let curr_market_id = queue.withdraw_queue[i];
+    // remove from queue 
+    accounts.market_config.cap = 0; 
+    accounts.queue.withdraw_queue.remove(market_index);
+    
+    Ok(())
+  }
 
-      if curr_market_id == args.market_id {
+  fn find_market_in_queue(queue: &QueueState, market_id: &Pubkey) -> Result<usize> {
+    queue.withdraw_queue
+      .iter()
+      .position(|&id| id == *market_id)
+      .ok_or_else(|| error!(ManagerError::MarketNotInQueue))
+  }
 
-        if market_config.cap != 0 {
-          return err!(ManagerError::InvalidMarketRemovalNonZeroCap);
-        }
+  fn validate_market_removal_conditions(market_config: &ManagerMarketConfig) -> Result<()> {
+    require!(market_config.cap == 0, ManagerError::InvalidMarketRemovalNonZeroCap);
+    require!(market_config.pending_cap.valid_at == 0, ManagerError::PendingCap);
+    Ok(())
+  }
 
-        if market_config.pending_cap.valid_at != 0 {
-          return err!(ManagerError::PendingCap);
-        }
+  fn get_initialize_lender_shares(
+    accounts: &RemoveFromWithdrawQueue,
+  ) -> Result<u64> {
+    let lender_shares: LenderShares;
 
-        // Check if manager has position in market
-        if lender_shares.is_some() && lender_shares.as_ref().unwrap().shares != 0 {
-          if market_config.removable_at == 0 {
-              return err!(ManagerError::InvalidMarketRemovalNonZeroSupply);
-          }
-
-          let current_time = Clock::get()?.unix_timestamp as u64;
-          if current_time < market_config.removable_at {
-              return err!(ManagerError::InvalidMarketRemovalTimelockNotElapsed);
-          }
-        }
-
-        // clear market config
-        market_config.cap = 0;
-
-        // remove the item from the queue
-        queue.withdraw_queue.remove(i);
-
-        return Ok(());
-      }
+    if accounts.lender_shares.data_is_empty() {
+      Self::initialize_lender_shares(accounts)?;
+      lender_shares = Self::get_lender_shares_data(&accounts.lender_shares)?;
+    } else {
+      lender_shares = Self::validate_lender_shares(
+        &accounts.lender_shares,
+        &accounts.pathfinder_market,
+        &accounts.config,
+        &accounts.pathfinder_program
+      )?;
     }
 
-    // If we exit the loop without finding the market, it's not in the queue
-    return err!(ManagerError::MarketNotInQueue);
+    Ok(lender_shares.shares)
   }
+
+  fn initialize_lender_shares(accounts: &RemoveFromWithdrawQueue) -> Result<()> {
+    let cpi_ctx = CpiContext::new(
+      accounts.pathfinder_program.to_account_info(),
+      InitLenderShares {
+        user: accounts.user.to_account_info(),
+        config: accounts.pathfinder_config.to_account_info(),
+        market: accounts.pathfinder_market.to_account_info(),
+        lender_shares: accounts.lender_shares.to_account_info(),
+        system_program: accounts.system_program.to_account_info(),
+      }
+    );
+
+    init_lender_shares(cpi_ctx, InitLenderSharesArgs {
+      owner: accounts.config.key()
+    })
+  }
+
+  fn get_lender_shares_data(lender_shares: &AccountInfo) -> Result<LenderShares> {
+    let lender_shares_data = lender_shares.try_borrow_data()?;
+    let lender_shares_account = LenderShares::try_deserialize(&mut &lender_shares_data[..])?;
+    Ok(lender_shares_account)
+  }
+
+  fn validate_position_removal_conditions(
+    market_config: &ManagerMarketConfig, 
+    shares: u64
+  ) -> Result<()> {
+    if shares != 0 {
+      require!(market_config.removable_at != 0, ManagerError::InvalidMarketRemovalNonZeroSupply);
+      
+      let current_time = Clock::get()?.unix_timestamp as u64;
+      require!(
+        current_time >= market_config.removable_at, 
+        ManagerError::InvalidMarketRemovalTimelockNotElapsed
+      );
+    }
+    Ok(())
+  }
+
+  pub fn validate_lender_shares(
+    lender_shares: &AccountInfo,
+    pathfinder_market: &Account<Market>,
+    config: &Account<ManagerVaultConfig>,
+    pathfinder_program: &Program<Pathfinder>,
+  ) -> Result<LenderShares> {
+    // 1. Check program ownership
+    require!(
+        lender_shares.owner == &pathfinder_program.key(),
+        ManagerError::InvalidAccountOwner
+    );
+
+    // 2. Validate seed derivation
+    let expected_lender_shares = Pubkey::find_program_address(
+        &[
+            MARKET_SHARES_SEED_PREFIX,
+            pathfinder_market.key().as_ref(),
+            config.key().as_ref(),
+        ],
+        &pathfinder_program.key()
+    ).0;
+    
+    require!(
+        lender_shares.key() == expected_lender_shares,
+        ManagerError::InvalidSeeds
+    );
+
+    let lender_shares = Self::get_lender_shares_data(lender_shares)?;
+
+    Ok(lender_shares)
+  }
+
 }

--- a/programs/assistant-to-the-regional-manager/src/instructions/set_supply_queue.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/set_supply_queue.rs
@@ -57,8 +57,6 @@ impl<'info, 'c: 'info> SetSupplyQueue<'info> {
           ..
         } = ctx.accounts;
 
-        msg!("Setting supply queue to {:?}", args.market_ids.len());
-
         // Check queue length doesn't exceed max
         if args.market_ids.len() > MAX_QUEUE_LENGTH {
           return err!(ManagerError::MaxQueueLengthExceeded);

--- a/programs/assistant-to-the-regional-manager/src/instructions/set_supply_queue.rs
+++ b/programs/assistant-to-the-regional-manager/src/instructions/set_supply_queue.rs
@@ -57,6 +57,8 @@ impl<'info, 'c: 'info> SetSupplyQueue<'info> {
           ..
         } = ctx.accounts;
 
+        msg!("Setting supply queue to {:?}", args.market_ids.len());
+
         // Check queue length doesn't exceed max
         if args.market_ids.len() > MAX_QUEUE_LENGTH {
           return err!(ManagerError::MaxQueueLengthExceeded);
@@ -68,7 +70,6 @@ impl<'info, 'c: 'info> SetSupplyQueue<'info> {
           let market_config_info = &ctx.remaining_accounts[i];
 
           // retreive configs for each market account
-          // let manager_market_config = load_manager_market_config(market_config_info)?;
           let manager_market_config_account = Account::<ManagerMarketConfig>::try_from(&market_config_info)?;
 
           validate_manager_market_config_pda(

--- a/programs/assistant-to-the-regional-manager/src/lib.rs
+++ b/programs/assistant-to-the-regional-manager/src/lib.rs
@@ -66,7 +66,10 @@ pub mod assistant_to_the_regional_manager {
     }
 
     #[access_control(ctx.accounts.validate())]
-    pub fn remove_from_withdraw_queue(ctx: Context<RemoveFromWithdrawQueue>, args: RemoveFromWithdrawQueueArgs) -> Result<()> {
+    pub fn remove_from_withdraw_queue(
+        ctx: Context<RemoveFromWithdrawQueue>,
+        args: RemoveFromWithdrawQueueArgs
+    ) -> Result<()> {
         RemoveFromWithdrawQueue::handle(ctx, args)
     }
 

--- a/programs/pathfinder/src/instructions/init_lender_shares.rs
+++ b/programs/pathfinder/src/instructions/init_lender_shares.rs
@@ -1,0 +1,53 @@
+use anchor_lang::prelude::*;
+use crate::state::*;
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct InitLenderSharesArgs {
+    pub owner: Pubkey,
+}
+
+#[derive(Accounts)]
+#[instruction(args: InitLenderSharesArgs)]
+pub struct InitLenderShares<'info> {
+    #[account(mut)]
+    pub user: Signer<'info>,
+
+    #[account(
+        seeds = [CONFIG_SEED_PREFIX],
+        bump = config.bump,
+    )]
+    pub config: Box<Account<'info, Config>>,
+
+    #[account(
+        seeds = [
+            MARKET_SEED_PREFIX,
+            &market.quote_mint.key().as_ref(),
+            &market.collateral_mint.key().as_ref(),
+            &market.ltv_factor.to_le_bytes(),
+            &market.oracle.id.to_bytes(),
+        ],
+        bump = market.bump,
+    )]
+    pub market: Box<Account<'info, Market>>,
+
+    #[account(
+        init_if_needed,
+        payer = user,
+        space = 8 + std::mem::size_of::<LenderShares>(),
+        seeds = [
+            MARKET_SHARES_SEED_PREFIX,
+            market.key().as_ref(),
+            args.owner.key().as_ref()
+        ],
+        bump
+    )]
+    pub lender_shares: Box<Account<'info, LenderShares>>,
+
+    pub system_program: Program<'info, System>,
+}
+
+impl<'info> InitLenderShares<'info> {
+    pub fn handle(ctx: Context<Self>, args: InitLenderSharesArgs) -> Result<()> {
+        Ok(())
+    }
+}

--- a/programs/pathfinder/src/instructions/mod.rs
+++ b/programs/pathfinder/src/instructions/mod.rs
@@ -17,6 +17,7 @@ pub use views::*;
 pub use withdraw::*;
 pub use withdraw_collateral::*;
 pub use withdraw_fee::*;
+pub use init_lender_shares::*;
 
 pub mod init;
 pub mod accrue_interest;
@@ -36,3 +37,4 @@ pub mod views;
 pub mod withdraw;
 pub mod withdraw_collateral;
 pub mod withdraw_fee;
+pub mod init_lender_shares;

--- a/programs/pathfinder/src/lib.rs
+++ b/programs/pathfinder/src/lib.rs
@@ -39,6 +39,10 @@ pub mod pathfinder {
     Deposit::handle(ctx, args)
   }
 
+  pub fn init_lender_shares(ctx: Context<InitLenderShares>, args: InitLenderSharesArgs) -> Result<()> {
+    InitLenderShares::handle(ctx, args)
+  }
+
   #[access_control(ctx.accounts.validate())]
   pub fn borrow(ctx: Context<Borrow>, args: BorrowArgs) -> Result<()> {
     Borrow::handle(ctx, args)

--- a/tests/fixtures/manager.ts
+++ b/tests/fixtures/manager.ts
@@ -373,28 +373,27 @@ export class ManagerFixture {
 
   async removeFromWithdrawQueue({
     user,
-    marketId,
+    market,
   }: {
     user: UserFixture;
-    marketId: PublicKey;
+    market: MarketFixture;
   }): Promise<void> {
-
-    const market = this.get_market(marketId);
 
     await this.program.methods
       .removeFromWithdrawQueue({
-        marketId,
+        marketId: market.marketAcc.key,
       })
       .accounts({
         user: user.key.publicKey,
         config: this.managerVaultConfigAcc.key,
         allocator: (await this.get_allocator(user.key.publicKey))?.key || null,
-        marketConfig: this.get_market_config(marketId).key,
+        marketConfig: this.get_market_config(market.marketAcc.key).key,
         quoteMint: this.quoteMint,
         queue: this.queue.key,
-        lenderShares: null,
-        // TODO: test once deposits are functional
-        // lenderShares: market.get_lender_shares(ASSISTANT_TO_THE_REGIONAL_MANAGER_PROGRAM_ID).key,
+        pathfinderMarket: market.marketAcc.key,
+        pathfinderConfig: market.get_config().key,
+        pathfinderProgram: PATHFINDER_PROGRAM_ID,
+        lenderShares: market.get_lender_shares(this.managerVaultConfigAcc.key).key,
         tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
         systemProgram: anchor.web3.SystemProgram.programId,
       })
@@ -756,8 +755,6 @@ export class ManagerFixture {
       deriveAllocatorAccount(this.managerVaultConfigAcc.key, user, this.program.programId),
       this.program,
     );
-
-    console.log("allocator here:", await allocator.get_data());
 
     if (await allocator.get_data() == undefined) {
       return null;

--- a/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/deposit.ts
@@ -769,7 +769,7 @@ describe("deposit", () => {
     // remove one from withdraw queue
     await manager.removeFromWithdrawQueue({
       user: owen,
-      marketId: market.marketAcc.key,
+      market: market,
     });
 
     // Verify queue differences
@@ -882,7 +882,5 @@ describe("deposit", () => {
       .get_lender_shares(manager.managerVaultConfigAcc.key)
       .get_data();
     assert.equal(postManagerVaultDataMeta.shares.toNumber(), 100_000 * 1e9);
-
   });
-
 });

--- a/tests/user-actions/assistant-to-the-regional-manager/queue.ts
+++ b/tests/user-actions/assistant-to-the-regional-manager/queue.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@coral-xyz/anchor";
 import { BN, Program } from "@coral-xyz/anchor";
-import { TestUtils, PATHFINDER_PROGRAM_ID, deriveMarketConfigAccount, ONE_DAY_TIMELOCK } from "../../utils";
+import { TestUtils, MAX_QUEUE_LENGTH, PATHFINDER_PROGRAM_ID, deriveMarketConfigAccount, ONE_DAY_TIMELOCK } from "../../utils";
 import { ManagerFixture, MarketFixture, UserFixture } from "../../fixtures";
 import { AssistantToTheRegionalManager } from "../../../target/types/assistant_to_the_regional_manager";
 import assert from "assert";
@@ -13,6 +13,7 @@ describe("queue", () => {
   let carol: UserFixture;
   let alice: UserFixture;
   let futarchy: UserFixture;
+  let dan: UserFixture;
   let market: MarketFixture;
   let metaMarket: MarketFixture;
 
@@ -23,6 +24,11 @@ describe("queue", () => {
 
     owen = await test.createUser(
       new anchor.BN(1_000 * 1e9),
+      new anchor.BN(0)
+    );
+
+    dan = await test.createUser(
+      new anchor.BN(1_000_000 * 1e9),
       new anchor.BN(0)
     );
 
@@ -46,6 +52,16 @@ describe("queue", () => {
       authority: futarchy,
     });
 
+    market = await test.createMarket({
+      user: futarchy,
+      symbol: "BONK",
+      ltvFactor: new anchor.BN(0),
+      price: new anchor.BN(100 * 1e9),
+      conf: new anchor.BN(100 / 10 * 1e9),
+      expo: -9,
+      authority: futarchy,
+    });
+
     metaMarket = await test.createMarket({
       user: futarchy,
       symbol: "META",
@@ -56,9 +72,6 @@ describe("queue", () => {
       authority: futarchy,
     });
 
-    // await metaMarket.createAndSetAuthority({ authority: futarchy, payerAndRecipient: owen });
-    return;
-
     // initialize and create a market config
     manager = await test.initManagerFixture([market, metaMarket]); 
 
@@ -67,322 +80,330 @@ describe("queue", () => {
       symbol: "USDCM",
       name: "USDC Manager",
     });
+  });
 
+  it("should set supply queue correctly", async () => {
+
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
+
+    // pass 1 day + 1hr for timelock
+    await test.moveTimeForward(60 * 60 * 25);
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
+ 
+    // Create supply queue with two markets
+    const supplyQueue = [
+      market.marketAcc.key, // Using first market from fixture
+    ];
+
+    // Set the supply queue
+    await manager.setSupplyQueue({
+      user: owen,
+      marketIds: supplyQueue
+    })
+
+    // Verify queue was set correctly
+    const queueAccount = await manager.queue.getSupplyQueue();
+    assert.deepEqual(queueAccount, supplyQueue);
   });
 
   it("errors if market config acc for pathfinder market has not been initialized", async () => {
-    return;
     await assert.rejects(
       async () => {
         await manager.setSupplyQueue({
           user: owen,
           marketIds: [
-            market.marketAcc.key,
+            anchor.web3.Keypair.generate().publicKey,
           ],
         });
       },
       (err: anchor.AnchorError) => {
-        assert.strictEqual(err.error.errorMessage, "Invalid market config");
+        assert.strictEqual(err.error.errorMessage, "The program expected this account to be already initialized");
         return true;
       }
     );
   });
 
-    // function testMintAllCapsReached() public {
-    //   vm.prank(ALLOCATOR);
-    //   vault.setSupplyQueue(new Id[](0));
+it("should not allow submitting cap for market pending removal", async () => {
 
-    //   loanToken.setBalance(SUPPLIER, 1);
+  await manager.setCurator({
+    user: owen,
+    newCurator: carol,
+  })
 
-    //   vm.prank(SUPPLIER);
-    //   loanToken.approve(address(vault), type(uint256).max);
+  await test.moveTimeForward(ONE_DAY_TIMELOCK.toNumber() + 1);
 
-    //   vm.expectRevert(ErrorsLib.AllCapsReached.selector);
-    //   vm.prank(SUPPLIER);
-    //   vault.mint(1, RECEIVER);
-    // }
+  // Start acting as curator
+  await manager.submitCap({
+    user: carol,
+    marketId: market.marketAcc.key,
+    supplyCap: new BN(1e9)
+  })
 
-//     function testDepositAllCapsReached() public {
-//       vm.prank(ALLOCATOR);
-//       vault.setSupplyQueue(new Id[](0));
+  await test.moveTimeForward(ONE_DAY_TIMELOCK.toNumber() + 1);
 
-//       loanToken.setBalance(SUPPLIER, 1);
+  await manager.acceptCap({
+    user: carol,
+    marketId: market.marketAcc.key,
+  })
 
-//       vm.prank(SUPPLIER);
-//       loanToken.approve(address(vault), type(uint256).max);
+  await manager.submitCap({
+    user: carol,
+    marketId: market.marketAcc.key,
+    supplyCap: new BN(0),
+  })
 
-//       vm.expectRevert(ErrorsLib.AllCapsReached.selector);
-//       vm.prank(SUPPLIER);
-//       vault.deposit(1, RECEIVER);
-//     }
+  await manager.submitMarketRemoval({
+    user: carol,
+    marketId: market.marketAcc.key,
+  })
 
+  await assert.rejects(
+    async () => {
+      await manager.submitCap({
+        user: carol,
+        marketId: market.marketAcc.key,
+        supplyCap: new BN(1e9)
+      })
+    },
+    (err: anchor.AnchorError) => {
+      assert.strictEqual(err.error.errorMessage, "Market is pending removal");
+      return true;
+    }
+  );
+});
 
-// it("should not allow submitting cap for market pending removal", async () => {
+it("should reject setting supply queue when exceeding max length", async () => {
 
-//   await manager.setCurator({
-//     user: owen,
-//     newCurator: carol,
-//   })
+  await manager.submitCap({
+    user: owen,
+    marketId: market.marketAcc.key,
+    supplyCap: new anchor.BN(1_000_000 * 1e9),
+  });
 
-//   await test.moveTimeForward(ONE_DAY_TIMELOCK.toNumber() + 1);
+  // pass 1 day + 1hr for timelock
+  await test.moveTimeForward(60 * 60 * 25);
 
-//   // Start acting as curator
-//   await manager.submitCap({
-//     user: carol,
-//     marketId: market.marketAcc.key,
-//     supplyCap: new BN(1e9)
-//   })
+  await manager.acceptCap({
+    user: owen,
+    marketId: market.marketAcc.key,
+  });
 
-//   await assert.rejects(
-//     async () => {
-//       await manager.submitMarketRemoval({
-//         user: carol,
-//         marketId: market.marketAcc.key,
-//       })
-//     },
-//     (err: anchor.AnchorError) => {
-//       assert.strictEqual(err.error.errorMessage, "Market is not enabled");
-//       return true;
-//     }
-//   );
-// });
+  // Create supply queue that exceeds max length
+  const supplyQueue = Array(MAX_QUEUE_LENGTH.toNumber() + 1).fill(market.marketAcc.key);
 
-// it("should set supply queue correctly", async () => {
-
-//   await manager.submitCap({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//     supplyCap: new anchor.BN(1_000_000 * 1e9),
-//   });
-
-//   // pass 1 day + 1hr for timelock
-//   await test.moveTimeForward(60 * 60 * 25);
-
-//   await manager.acceptCap({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//   });
-
-  
-//   // Create supply queue with two markets
-//   const supplyQueue = [
-//     market.marketAcc.key, // Using first market from fixture
-//   ];
-
-//   // Set the supply queue
-//   await manager.setSupplyQueue({
-//     user: owen,
-//     marketIds: supplyQueue
-//   })
-
-//   // Verify queue was set correctly
-//   const queueAccount = await manager.queue.getSupplyQueue();
-//   assert.deepEqual(queueAccount, supplyQueue);
-// });
-
-// it("should reject setting supply queue when exceeding max length", async () => {
-//   // Create supply queue that exceeds max length
-//   const supplyQueue = Array(11).fill(market.marketAcc.key);
-
-//   // Attempt to set supply queue and expect rejection
-//   await assert.rejects(
-//     async () => {
-//       await manager.setSupplyQueue({
-//         user: owen,
-//         marketIds: supplyQueue
-//       });
-//     },
-//     (err: anchor.AnchorError) => {
-//       assert.strictEqual(err.error.errorMessage, "Max queue length exceeded");
-//       return true;
-//     }
-//   );
-// });
+  // Attempt to set supply queue and expect rejection
+  await assert.rejects(
+    async () => {
+      await manager.setSupplyQueue({
+        user: owen,
+        marketIds: supplyQueue
+      });
+    },
+    (err: anchor.AnchorError) => {
+      assert.strictEqual(err.error.errorMessage, "Max queue length exceeded");
+      return true;
+    }
+  );
+});
 
 
-// it("should reject setting supply queue with unauthorized market", async () => {
+it("should reject setting supply queue with unauthorized market", async () => {[]
+  await manager.submitCap({
+    user: owen,
+    marketId: market.marketAcc.key,
+    supplyCap: new anchor.BN(1_000_000 * 1e9),
+  });
 
-//   await manager.submitCap({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//     supplyCap: new anchor.BN(1_000_000 * 1e9),
-//   });
+  // pass 1 day + 1hr for timelock
+  await test.moveTimeForward(60 * 60 * 25);
 
-//   // pass 1 day + 1hr for timelock
-//   await test.moveTimeForward(60 * 60 * 25);
+  await manager.acceptCap({
+    user: owen,
+    marketId: market.marketAcc.key,
+  });
 
-//   await manager.acceptCap({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//   });
+  await manager.submitCap({
+    user: owen,
+    marketId: market.marketAcc.key,
+    supplyCap: new anchor.BN(0),
+  });
 
-//   await manager.submitCap({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//     supplyCap: new anchor.BN(0),
-//   });
+  await manager.submitMarketRemoval({
+    user: owen,
+    marketId: market.marketAcc.key,
+  });
 
-//   await manager.submitMarketRemoval({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//   });
+  // pass 1 day + 1hr for timelock
+  await test.moveTimeForward(60 * 60 * 25);
 
-//   // Create supply queue with unauthorized market
-//   const supplyQueue = [market.marketAcc.key];
+  // Verify market is no longer authorized
+  const marketConfig = manager.get_market_config(market.marketAcc.key);
+  const marketConfigData = await marketConfig.get_data();
+  assert.equal(marketConfigData.cap.toNumber(), 0, "Market should be disabled");
 
-//   // Attempt to set supply queue and expect rejection
-//   await assert.rejects(
-//     async () => {
-//       await manager.setSupplyQueue({
-//         user: owen,
-//         marketIds: supplyQueue
-//       });
-//     },
-//     (err: anchor.AnchorError) => {
-//       assert.strictEqual(err.error.errorMessage, "Unauthorized market");
-//       return true;
-//     }
-//   );
-// });
+  // Create supply queue with unauthorized market
+  const supplyQueue = [market.marketAcc.key];
 
-//   it("should successfully reorderwithdraw queue", async () => {
+  // Attempt to set supply queue and expect rejection
+  await assert.rejects(
+    async () => {
+      await manager.setSupplyQueue({
+        user: owen,
+        marketIds: supplyQueue
+      });
+    },
+    (err: anchor.AnchorError) => {
+      assert.strictEqual(err.error.errorMessage, "Unauthorized market");
+      return true;
+    }
+  );
+});
 
-//   // Submit initial cap for market
-//   await manager.submitCap({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//     supplyCap: new anchor.BN(1_000_000 * 1e9),
-//   });
+  it("should successfully reorder withdraw queue", async () => {
+  // Submit initial cap for market
+  await manager.submitCap({
+    user: owen,
+    marketId: market.marketAcc.key,
+    supplyCap: new anchor.BN(1_000_000 * 1e9),
+  });
 
-//   // Submit initial cap for market
-//   await manager.submitCap({
-//     user: owen,
-//     marketId: metaMarket.marketAcc.key,
-//     supplyCap: new anchor.BN(1_000_000 * 1e9),
-//   });
+  // Submit initial cap for market
+  await manager.submitCap({
+    user: owen,
+    marketId: metaMarket.marketAcc.key,
+    supplyCap: new anchor.BN(1_000_000 * 1e9),
+  });
 
-//   // Wait for timelock to pass
-//   await test.moveTimeForward(60 * 60 * 25);
+  // Wait for timelock to pass
+  await test.moveTimeForward(60 * 60 * 25);
 
-//   // Accept the cap
-//   await manager.acceptCap({
-//     user: owen,
-//     marketId: market.marketAcc.key,
-//   });
+  // Accept the cap
+  await manager.acceptCap({
+    user: owen,
+    marketId: market.marketAcc.key,
+  });
 
-//   await manager.acceptCap({
-//     user: owen,
-//     marketId: metaMarket.marketAcc.key,
-//   });
+  await manager.acceptCap({
+    user: owen,
+    marketId: metaMarket.marketAcc.key,
+  });
 
-//   // Verify initial withdraw queue state
-//   const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
-//   const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
-//   assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
-//   assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
+  // Verify initial withdraw queue state
+  const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
+  const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
+  assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
+  assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
 
-//   // Create reordered withdraw queue
-//   const updatedWithdrawQueue = [metaMarket.marketAcc.key, market.marketAcc.key];
+  // Create reordered withdraw queue
+  const updatedWithdrawQueue = [metaMarket.marketAcc.key, market.marketAcc.key];
 
-//   // Update withdraw queue order
-//   await manager.reorderWithdrawQueue({
-//     user: owen,
-//     marketIds: updatedWithdrawQueue
-//   });
+  // Update withdraw queue order
+  await manager.reorderWithdrawQueue({
+    user: owen,
+    marketIds: updatedWithdrawQueue
+  });
 
-//   // Verify queue matches expected order
-//   const withdrawQueueData = await manager.queue.getWithdrawQueue();
-//   assert.equal(withdrawQueueData[0].toBase58(), updatedWithdrawQueue[0].toBase58());
-//   assert.equal(withdrawQueueData[1].toBase58(), updatedWithdrawQueue[1].toBase58());
-// });
+  // Verify queue matches expected order
+  const withdrawQueueData = await manager.queue.getWithdrawQueue();
+  assert.equal(withdrawQueueData[0].toBase58(), updatedWithdrawQueue[0].toBase58());
+  assert.equal(withdrawQueueData[1].toBase58(), updatedWithdrawQueue[1].toBase58());
+});
 
-//   it("should successfully remove disabled market", async () => {
+  it("should successfully remove disabled market", async () => {
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
 
-//     // Submit initial cap for market
-//     await manager.submitCap({
-//       user: owen,
-//       marketId: market.marketAcc.key,
-//       supplyCap: new anchor.BN(1_000_000 * 1e9),
-//     });
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
 
-//     // Submit initial cap for market
-//     await manager.submitCap({
-//       user: owen,
-//       marketId: metaMarket.marketAcc.key,
-//       supplyCap: new anchor.BN(1_000_000 * 1e9),
-//     });
+    // Wait for timelock to pass
+    await test.moveTimeForward(60 * 60 * 25);
 
-//     // Wait for timelock to pass
-//     await test.moveTimeForward(60 * 60 * 25);
+    // Accept the cap
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
 
-//     // Accept the cap
-//     await manager.acceptCap({
-//       user: owen,
-//       marketId: market.marketAcc.key,
-//     });
+    await manager.acceptCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+    });
 
-//     await manager.acceptCap({
-//       user: owen,
-//       marketId: metaMarket.marketAcc.key,
-//     });
+    // Verify initial withdraw queue state
+    const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
+    const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(initialWithdrawQueueData.length, 2);
+    assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
+    assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
 
-//     // Verify initial withdraw queue state
-//     const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
-//     const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
-//     assert.equal(initialWithdrawQueueData.length, 2);
-//     assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
-//     assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
+    // Try to remove market before cap is set to 0
+    await assert.rejects(
+      async () => {
+        await manager.removeFromWithdrawQueue({
+          user: owen,
+          market: market
+        });
+      },
+      (err: anchor.AnchorError) => {
+        console.log(err);
+        assert.strictEqual(err.error.errorMessage, "Invalid market removal non-zero cap");
+        return true;
+      }
+    );
 
-//     // Try to remove market before cap is set to 0
-//     await assert.rejects(
-//       async () => {
-//         await manager.removeFromWithdrawQueue({
-//           user: owen,
-//           marketId: market.marketAcc.key
-//         });
-//       },
-//       (err: anchor.AnchorError) => {
-//         assert.strictEqual(err.error.errorMessage, "Invalid market removal non-zero cap");
-//         return true;
-//       }
-//     );
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(0),
+    });
 
-//     // Submit initial cap for market
-//     await manager.submitCap({
-//       user: owen,
-//       marketId: market.marketAcc.key,
-//       supplyCap: new anchor.BN(0),
-//     });
+    // Update withdraw queue order
+    await manager.removeFromWithdrawQueue({
+      user: owen,
+      market: market
+    });
 
-//     // Update withdraw queue order
-//     await manager.removeFromWithdrawQueue({
-//       user: owen,
-//       marketId: market.marketAcc.key
-//     });
+    const withdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(withdrawQueueData.length, 1);
+    assert.equal(withdrawQueueData[0].toBase58(), metaMarket.marketAcc.key.toBase58());
 
-//     const withdrawQueueData = await manager.queue.getWithdrawQueue();
-//     assert.equal(withdrawQueueData.length, 1);
-//     assert.equal(withdrawQueueData[0].toBase58(), metaMarket.marketAcc.key.toBase58());
-
-//     // Try to remove market again
-//     await assert.rejects(
-//       async () => {
-//         await manager.removeFromWithdrawQueue({
-//           user: owen,
-//           marketId: market.marketAcc.key
-//         });
-//       },
-//       (err: anchor.AnchorError) => {
-//         try {
-//           assert.strictEqual(err.error.errorMessage, "Market not in queue");
-//         } catch {
-//           // happens when banks client submits the same transaction twice, thinks its already processed
-//           assert.ok(err.toString().includes("transaction has already been processed"));
-//         }
-//         return true;
-//       }
-//     );
-//   })
+    // Try to remove market again
+    await assert.rejects(
+      async () => {
+        await manager.removeFromWithdrawQueue({
+          user: owen,
+          market: market
+        });
+      },
+      (err: anchor.AnchorError) => {
+        try {
+          assert.strictEqual(err.error.errorMessage, "Market not in queue");
+        } catch {
+          // happens when banks client submits the same transaction twice, thinks its already processed
+          assert.ok(err.toString().includes("transaction has already been processed"));
+        }
+        return true;
+      }
+    );
+  })
 
 
   // Market removal test scenario with deposits
@@ -393,233 +414,346 @@ describe("queue", () => {
   // • Try removing from withdraw queue (allocator role)
   // • Confirm removal succeeds (config[id] is deleted)
   // • Verify market funds are still accessible
-  // • Attempt deposits to removed market (should fail)
-  it("should not fail to remove market with non-zero supply", async () => {
-    // TODO: when deposit is implemented
+  it("remove market with non-zero supply", async () => {
+
+    //TODO: revist, should this be possible?
+
+    // submit caps
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
+
+    await manager.submitCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
+
+    // pass 1 day + 1hr for timelock
+    await test.moveTimeForward(60 * 60 * 25);
+
+    // accept caps
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
+
+    await manager.acceptCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+    });
+ 
+    // set supply queue with two markets
+    const supplyQueue = [
+      market.marketAcc.key, // Using first market from fixture
+      metaMarket.marketAcc.key,
+    ];
+
+    await manager.setSupplyQueue({
+      user: owen,
+      marketIds: supplyQueue
+    })
+
+    const queueAccount = await manager.queue.getSupplyQueue();
+    assert.deepEqual(queueAccount, supplyQueue);
+
+    // deposit assets
+    await manager.depositCustomCU({
+      user: dan,
+      receiver: dan,
+      markets: [market, metaMarket],
+      assets: new anchor.BN(500_000 * 1e9),
+      customCU: 1_000_000,
+    });
+
+    // shared vault balance should be 500_000
+    assert.equal(Number(await market.quoteAta.getTokenBalance()), 500_000 * 1e9);
+
+    // Dan's balance should be reduced by deposit amount
+    assert.equal(Number(await dan.get_quo_balance()), 500_000 * 1e9);
+
+    // Verify last_total_assets was updated in config
+    const configData = await manager.managerVaultConfigAcc.get_data();
+    assert.equal(configData.lastTotalAssets.toNumber(), 500_000 * 1e9);
+
+    // manager vault owns shares in base market
+    const postManagerVaultData = await market
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postManagerVaultData.shares.toNumber(), 500_000 * 1e9);
+
+    // Verify dans shares were created correctly
+    const danShares = await manager.get_supply_shares(dan.key.publicKey).get_data();
+    assert.equal(danShares.shares.toNumber(), 500_000 * 1e9);
+
+    // submit cap for market to remove
+    await manager.submitCap({
+      user: owen,
+      marketId:  market.marketAcc.key,
+      supplyCap: new anchor.BN(0),
+    });
+
+    await manager.submitMarketRemoval({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
+
+    // Try to remove market before timelock elapses
+    await assert.rejects(
+      async () => {
+        await manager.removeFromWithdrawQueue({
+          user: owen,
+          market: market,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        assert.strictEqual(err.error.errorMessage, "Invalid market removal timelock not elapsed");
+        return true;
+      }
+    );
+
+    // pass 1 day + 1hr for timelock
+    await test.moveTimeForward(60 * 60 * 25);
+
+    await manager.removeFromWithdrawQueue({
+      user: owen,
+      market: market,
+    });
+
+    // verify market is removed
+    const marketConfig = manager.get_market_config(market.marketAcc.key);
+    const marketConfigData = await marketConfig.get_data();
+    assert.equal(marketConfigData.cap.toNumber(), 0, "Market should be disabled");
+
+    // verify market is removed from withdraw queue
+    const withdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(withdrawQueueData.length, 1);
+    assert.equal(withdrawQueueData[0].toBase58(), metaMarket.marketAcc.key.toBase58());
+
+    // verify manager vault still holds shares in removed market
+    const postRemovalManagerVaultData = await market
+      .get_lender_shares(manager.managerVaultConfigAcc.key)
+      .get_data();
+    assert.equal(postRemovalManagerVaultData.shares.toNumber(), 500_000 * 1e9);
+
   });
 
-  it("should not allow updating withdraw queue when market removal timelock has not elapsed", async () => {
-    // TODO: when deposit is implemented
-  });
+  it("curator and allocator should be able to update withdraw queue", async () => {
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
 
-  // it("curator and allocator should be able to update withdraw queue", async () => {
-  //   // Submit initial cap for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //     supplyCap: new anchor.BN(1_000_000 * 1e9),
-  //   });
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
 
-  //   // Submit initial cap for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: metaMarket.marketAcc.key,
-  //     supplyCap: new anchor.BN(1_000_000 * 1e9),
-  //   });
+    // Wait for timelock to pass
+    await test.moveTimeForward(60 * 60 * 25);
 
-  //   // Wait for timelock to pass
-  //   await test.moveTimeForward(60 * 60 * 25);
+    // Accept the cap
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
 
-  //   // Accept the cap
-  //   await manager.acceptCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //   });
+    await manager.acceptCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+    });
 
-  //   await manager.acceptCap({
-  //     user: owen,
-  //     marketId: metaMarket.marketAcc.key,
-  //   });
+    // Verify initial withdraw queue state
+    const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
+    const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
+    assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
 
-  //   // Verify initial withdraw queue state
-  //   const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
-  //   const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
-  //   assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
-  //   assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
+    // Create reordered withdraw queue
+    const updatedWithdrawQueue = [metaMarket.marketAcc.key, market.marketAcc.key];
 
-  //   // Create reordered withdraw queue
-  //   const updatedWithdrawQueue = [metaMarket.marketAcc.key, market.marketAcc.key];
+    // non-allocator, non-owner, non-curator should not be able to reorder withdraw queue
+    await assert.rejects(
+      async () => {
+        await manager.reorderWithdrawQueue({
+          user: futarchy, // non-allocator, non-owner, non-curator
+          marketIds: updatedWithdrawQueue,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        assert.strictEqual(err.error.errorMessage, "Unauthorized signer");
+        return true;
+      }
+    );
 
-  //   // non-allocator, non-owner, non-curator should not be able to reorder withdraw queue
-  //   await assert.rejects(
-  //     async () => {
-  //       await manager.reorderWithdrawQueue({
-  //         user: futarchy, // non-allocator, non-owner, non-curator
-  //         marketIds: updatedWithdrawQueue,
-  //       });
-  //     },
-  //     (err: anchor.AnchorError) => {
-  //       assert.strictEqual(err.error.errorMessage, "Unauthorized signer");
-  //       return true;
-  //     }
-  //   );
+    // set carol as curator
+    await manager.setCurator({
+      user: owen,
+      newCurator: carol,
+    });
 
-  //   // set carol as curator
-  //   await manager.setCurator({
-  //     user: owen,
-  //     newCurator: carol,
-  //   });
+    // wait for timelock to pass
+    await test.moveTimeForward(ONE_DAY_TIMELOCK.toNumber() + 1);
 
-  //   // wait for timelock to pass
-  //   await test.moveTimeForward(ONE_DAY_TIMELOCK.toNumber() + 1);
+    // curator should be able to reorder withdraw queue
+    await manager.reorderWithdrawQueue({
+      user: carol, // curator
+      marketIds: updatedWithdrawQueue,
+    });
 
-  //   // curator should be able to reorder withdraw queue
-  //   await manager.reorderWithdrawQueue({
-  //     user: carol, // curator
-  //     marketIds: updatedWithdrawQueue,
-  //   });
+    // Verify queue matches expected order
+    const withdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(withdrawQueueData[0].toBase58(), updatedWithdrawQueue[0].toBase58());
+    assert.equal(withdrawQueueData[1].toBase58(), updatedWithdrawQueue[1].toBase58());
 
-  //   // Verify queue matches expected order
-  //   const withdrawQueueData = await manager.queue.getWithdrawQueue();
-  //   assert.equal(withdrawQueueData[0].toBase58(), updatedWithdrawQueue[0].toBase58());
-  //   assert.equal(withdrawQueueData[1].toBase58(), updatedWithdrawQueue[1].toBase58());
+    // set alice as allocator
+    await manager.setAllocator({
+      user: owen,
+      newAllocator: alice,
+      isAllocator: true,
+    });
 
-  //   // set alice as allocator
-  //   await manager.setAllocator({
-  //     user: owen,
-  //     newAllocator: alice,
-  //     isAllocator: true,
-  //   });
+    // Create reordered withdraw queue
+    const aliceWithdrawQueue = [metaMarket.marketAcc.key, market.marketAcc.key];
 
-  //   // Create reordered withdraw queue
-  //   const aliceWithdrawQueue = [metaMarket.marketAcc.key, market.marketAcc.key];
-
-  //   // alice should be able to reorder withdraw queue
-  //   await manager.reorderWithdrawQueue({
-  //     user: alice, // allocator
-  //     marketIds: aliceWithdrawQueue,
-  //   });
+    // alice should be able to reorder withdraw queue
+    await manager.reorderWithdrawQueue({
+      user: alice, // allocator
+      marketIds: aliceWithdrawQueue,
+    });
     
-  //   // Verify queue matches expected order
-  //   const aliceWithdrawQueueData = await manager.queue.getWithdrawQueue();
-  //   assert.equal(aliceWithdrawQueueData[0].toBase58(), aliceWithdrawQueue[0].toBase58());
-  //   assert.equal(aliceWithdrawQueueData[1].toBase58(), aliceWithdrawQueue[1].toBase58());
+    // Verify queue matches expected order
+    const aliceWithdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(aliceWithdrawQueueData[0].toBase58(), aliceWithdrawQueue[0].toBase58());
+    assert.equal(aliceWithdrawQueueData[1].toBase58(), aliceWithdrawQueue[1].toBase58());
 
-  // })
+  })
 
-  // it("allocator should successfully remove disabled market", async () => {
+  it("allocator should successfully remove disabled market", async () => {
 
-  //   // Submit initial cap for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //     supplyCap: new anchor.BN(1_000_000 * 1e9),
-  //   });
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
 
-  //   // Submit initial cap for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: metaMarket.marketAcc.key,
-  //     supplyCap: new anchor.BN(1_000_000 * 1e9),
-  //   });
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9),
+    });
 
-  //   // Wait for timelock to pass
-  //   await test.moveTimeForward(60 * 60 * 25);
+    // Wait for timelock to pass
+    await test.moveTimeForward(60 * 60 * 25);
 
-  //   // Accept the cap
-  //   await manager.acceptCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //   });
+    // Accept the cap
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
 
-  //   await manager.acceptCap({
-  //     user: owen,
-  //     marketId: metaMarket.marketAcc.key,
-  //   });
+    await manager.acceptCap({
+      user: owen,
+      marketId: metaMarket.marketAcc.key,
+    });
 
-  //   // Verify initial withdraw queue state
-  //   const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
-  //   const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
-  //   assert.equal(initialWithdrawQueueData.length, 2);
-  //   assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
-  //   assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
+    // Verify initial withdraw queue state
+    const initialWithdrawQueue = [market.marketAcc.key, metaMarket.marketAcc.key];
+    const initialWithdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(initialWithdrawQueueData.length, 2);
+    assert.equal(initialWithdrawQueueData[0].toBase58(), initialWithdrawQueue[0].toBase58());
+    assert.equal(initialWithdrawQueueData[1].toBase58(), initialWithdrawQueue[1].toBase58());
 
-  //   // Submit initial cap for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //     supplyCap: new anchor.BN(0),
-  //   });
+    // Submit initial cap for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(0),
+    });
 
-  //   // non-allocator, non-owner, non-curator should not be able to remove market
-  //   await assert.rejects(
-  //     async () => {
-  //       await manager.removeFromWithdrawQueue({
-  //         user: futarchy,
-  //         marketId: market.marketAcc.key
-  //       });
-  //     },
-  //     (err: anchor.AnchorError) => {
-  //       assert.strictEqual(err.error.errorMessage, "Unauthorized signer");
-  //       return true;
-  //     }
-  //   );
+    // non-allocator, non-owner, non-curator should not be able to remove market
+    await assert.rejects(
+      async () => {
+        await manager.removeFromWithdrawQueue({
+          user: futarchy,
+          market: market,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        assert.strictEqual(err.error.errorMessage, "Unauthorized signer");
+        return true;
+      }
+    );
 
-  //   // set alice as allocator
-  //   await manager.setAllocator({
-  //     user: owen,
-  //     newAllocator: alice,
-  //     isAllocator: true,
-  //   });
+    // set alice as allocator
+    await manager.setAllocator({
+      user: owen,
+      newAllocator: alice,
+      isAllocator: true,
+    });
 
-  //   // allocator should be able to remove market
-  //   await manager.removeFromWithdrawQueue({
-  //     user: alice,
-  //     marketId: market.marketAcc.key
-  //   });
+    // allocator should be able to remove market
+    await manager.removeFromWithdrawQueue({
+      user: alice,
+      market: market,
+    });
 
-  //   const withdrawQueueData = await manager.queue.getWithdrawQueue();
-  //   assert.equal(withdrawQueueData.length, 1);
-  //   assert.equal(withdrawQueueData[0].toBase58(), metaMarket.marketAcc.key.toBase58());
+    const withdrawQueueData = await manager.queue.getWithdrawQueue();
+    assert.equal(withdrawQueueData.length, 1);
+    assert.equal(withdrawQueueData[0].toBase58(), metaMarket.marketAcc.key.toBase58());
 
-  // })
+  })
 
-  // it("should not allow updating withdraw queue when market has pending cap", async () => {
-  //   // Submit cap change for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //     supplyCap: new anchor.BN(1_000_000 * 1e9)
-  //   });
+  it("should not allow updating withdraw queue when market has pending cap", async () => {
+    // Submit cap change for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_000 * 1e9)
+    });
 
-  //   await test.moveTimeForward(60 * 60 * 25);
+    await test.moveTimeForward(60 * 60 * 25);
 
-  //   await manager.acceptCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //   });
+    await manager.acceptCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+    });
 
-  //   // Submit cap change for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //     supplyCap: new anchor.BN(0)
-  //   });
+    // Submit cap change for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(0)
+    });
 
-  //   // Submit cap change for market
-  //   await manager.submitCap({
-  //     user: owen,
-  //     marketId: market.marketAcc.key,
-  //     supplyCap: new anchor.BN(1_000_001 * 1e9)
-  //   });
+    // Submit cap change for market
+    await manager.submitCap({
+      user: owen,
+      marketId: market.marketAcc.key,
+      supplyCap: new anchor.BN(1_000_001 * 1e9)
+    });
 
-  //   // Try to update withdraw queue while market3 has pending cap
-  //   await assert.rejects(
-  //     async () => {
-  //       await manager.removeFromWithdrawQueue({
-  //         user: owen,
-  //         marketId: market.marketAcc.key,
-  //       });
-  //     },
-  //     (err: anchor.AnchorError) => {
-  //       assert.strictEqual(err.error.errorMessage, "Pending cap");
-  //       return true;
-  //     }
-  //   );
-  // }); 
-
-  // it("should enable market with liquidity", async () => {
-  //   // TODO: when deposit is implemented
-  // });
+    // Try to update withdraw queue while market3 has pending cap
+    await assert.rejects(
+      async () => {
+        await manager.removeFromWithdrawQueue({
+          user: owen,
+          market: market,
+        });
+      },
+      (err: anchor.AnchorError) => {
+        assert.strictEqual(err.error.errorMessage, "Pending cap");
+        return true;
+      }
+    );
+  }); 
 
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -21,6 +21,7 @@ export const COMMITMENT: { commitment: Finality } = { commitment: "confirmed" };
 
 export const TWENTY_FIVE_HOUR_TIMELOCK = new anchor.BN(25 * 60 * 60);
 export const ONE_DAY_TIMELOCK = new anchor.BN(24 * 60 * 60);
+export const MAX_QUEUE_LENGTH = new anchor.BN(6);
 
 export const PATHFINDER_PROGRAM_ID = new PublicKey("7ALFC87zvuPvpp9h5Stq9SSP3kTCUJfhtirEZVJmZYy4");
 export const ASSISTANT_TO_THE_REGIONAL_MANAGER_PROGRAM_ID = new PublicKey("ATRMG4WfodAcWb6K7mA2sFPLXBAKwppvxAQcp7t3Yd8v");
@@ -431,7 +432,7 @@ export class TestUtils {
       this.managerProgram,
       this.provider,
       this.quoteMint,
-      markets // a manager has a one to many relationship with markets but for testing purposes we can just pass in one market
+      markets
     );
   }
 


### PR DESCRIPTION
- completed several outstanding TODO queue tests
- made lenderShares in remove from withdraw queue required instead of optional as there was a potential attack where the curator could not pass the required lenderShares and remove a market